### PR TITLE
Adds runtime property formerly located in manifest

### DIFF
--- a/src/mod.ts
+++ b/src/mod.ts
@@ -3,6 +3,7 @@ export const RUNTIME_TAG = "deno_slack_runtime@0.0.4";
 
 export const projectScripts = () => {
   return {
+    "runtime": "deno",
     "hooks": {
       "get-manifest":
         `deno run -q --unstable --import-map=import_map.json --allow-read --allow-net https://deno.land/x/${BUILDER_TAG}/mod.ts --manifest`,


### PR DESCRIPTION
###  Summary

This change adds the `runtime` property to hooks library. `runtime` formerly existed in the manifest authoring layer but has been removed in favor of it living in project configuration (i.e. slack.json). This is the more correct place for this to live, as it's project specific and not app-specific (see: https://github.com/slackapi/deno-slack-sdk/pull/15). 

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/{project_slug}/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
