### PR TITLE
[HERMES-2554] Support disabling Deno SSL certificate verification via flag

### DIFF
--- a/src/deps.ts
+++ b/src/deps.ts
@@ -1,0 +1,1 @@
+export { parse } from "https://deno.land/std@0.138.0/flags/mod.ts";

--- a/src/dev_deps.ts
+++ b/src/dev_deps.ts
@@ -1,0 +1,6 @@
+export {
+  assertEquals,
+  assertRejects,
+  assertStringIncludes,
+} from "https://deno.land/std@0.132.0/testing/asserts.ts";
+export * from "https://deno.land/x/mock_fetch@0.3.0/mod.ts";

--- a/src/dev_deps.ts
+++ b/src/dev_deps.ts
@@ -1,6 +1,1 @@
-export {
-  assertEquals,
-  assertRejects,
-  assertStringIncludes,
-} from "https://deno.land/std@0.132.0/testing/asserts.ts";
-export * from "https://deno.land/x/mock_fetch@0.3.0/mod.ts";
+export { assertEquals } from "https://deno.land/std@0.132.0/testing/asserts.ts";

--- a/src/dev_deps.ts
+++ b/src/dev_deps.ts
@@ -1,1 +1,1 @@
-export { assertEquals } from "https://deno.land/std@0.132.0/testing/asserts.ts";
+export { assertEquals } from "https://deno.land/std@0.138.0/testing/asserts.ts";

--- a/src/flags.ts
+++ b/src/flags.ts
@@ -1,9 +1,9 @@
-import { parse } from "https://deno.land/std@0.138.0/flags/mod.ts";
+import { parse } from "./deps.ts";
 
 const UNSAFELY_IGNORE_CERT_ERRORS_FLAG =
   "sdk-unsafely-ignore-certificate-errors";
 
-export const getStartHookAdditionalFlags = (args: string[]): string => {
+export const getStartHookAdditionalDenoFlags = (args: string[]): string => {
   const parsedArgs = parse(args);
   let certErrorsFlag = "";
   if (parsedArgs[UNSAFELY_IGNORE_CERT_ERRORS_FLAG]) {

--- a/src/flags.ts
+++ b/src/flags.ts
@@ -1,0 +1,15 @@
+import { parse } from "https://deno.land/std@0.138.0/flags/mod.ts";
+
+const UNSAFELY_IGNORE_CERT_ERRORS_FLAG =
+  "sdk-unsafely-ignore-certificate-errors";
+
+export const getStartHookAdditionalFlags = (args: string[]): string => {
+  const parsedArgs = parse(args);
+  let certErrorsFlag = "";
+  if (parsedArgs[UNSAFELY_IGNORE_CERT_ERRORS_FLAG]) {
+    certErrorsFlag = `--unsafely-ignore-certificate-errors=${
+      parsedArgs[UNSAFELY_IGNORE_CERT_ERRORS_FLAG]
+    }`;
+  }
+  return certErrorsFlag;
+};

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -1,7 +1,10 @@
+import { getStartHookAdditionalFlags } from "./flags.ts";
+
 export const BUILDER_TAG = "deno_slack_builder@0.0.10";
 export const RUNTIME_TAG = "deno_slack_runtime@0.0.6";
 
-export const projectScripts = () => {
+export const projectScripts = (args: string[]) => {
+  const startHookFlags = getStartHookAdditionalFlags(args);
   return {
     "runtime": "deno",
     "hooks": {
@@ -10,7 +13,7 @@ export const projectScripts = () => {
       "build":
         `deno run -q --unstable --config=deno.jsonc --allow-read --allow-write --allow-net https://deno.land/x/${BUILDER_TAG}/mod.ts`,
       "start":
-        `deno run -q --unstable --config=deno.jsonc --allow-read --allow-net https://deno.land/x/${RUNTIME_TAG}/local-run.ts`,
+        `deno run -q --unstable --config=deno.jsonc --allow-read --allow-net ${startHookFlags} https://deno.land/x/${RUNTIME_TAG}/local-run.ts`,
     },
     "config": {
       "watch": {
@@ -22,5 +25,5 @@ export const projectScripts = () => {
 };
 
 if (import.meta.main) {
-  console.log(JSON.stringify(projectScripts()));
+  console.log(JSON.stringify(projectScripts(Deno.args)));
 }

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -1,10 +1,10 @@
-import { getStartHookAdditionalFlags } from "./flags.ts";
+import { getStartHookAdditionalDenoFlags } from "./flags.ts";
 
 export const BUILDER_TAG = "deno_slack_builder@0.0.10";
 export const RUNTIME_TAG = "deno_slack_runtime@0.0.6";
 
 export const projectScripts = (args: string[]) => {
-  const startHookFlags = getStartHookAdditionalFlags(args);
+  const startHookFlags = getStartHookAdditionalDenoFlags(args);
   return {
     "runtime": "deno",
     "hooks": {

--- a/src/tests/flags_test.ts
+++ b/src/tests/flags_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals, assertRejects } from "../dev_deps.ts";
+import { assertEquals } from "../dev_deps.ts";
 import { getStartHookAdditionalFlags } from "../flags.ts";
 
 Deno.test("getStartHookAdditionalFlags sets certificate validation flag, with =", () => {

--- a/src/tests/flags_test.ts
+++ b/src/tests/flags_test.ts
@@ -1,0 +1,31 @@
+import { assertEquals, assertRejects } from "../dev_deps.ts";
+import { getStartHookAdditionalFlags } from "../flags.ts";
+
+Deno.test("getStartHookAdditionalFlags sets certificate validation flag, with =", () => {
+  const result = getStartHookAdditionalFlags([
+    "--sdk-unsafely-ignore-certificate-errors=https://dev1234.slack.com",
+  ]);
+  assertEquals(
+    result,
+    "--unsafely-ignore-certificate-errors=https://dev1234.slack.com",
+  );
+});
+
+Deno.test("getStartHookAdditionalFlags sets certificate validation flag", () => {
+  const result = getStartHookAdditionalFlags([
+    "--sdk-unsafely-ignore-certificate-errors",
+    "https://dev1234.slack.com",
+  ]);
+  assertEquals(
+    result,
+    "--unsafely-ignore-certificate-errors=https://dev1234.slack.com",
+  );
+});
+
+Deno.test("getStartHookAdditionalFlags passes through empty flags", () => {
+  const result = getStartHookAdditionalFlags([]);
+  assertEquals(
+    result,
+    "",
+  );
+});

--- a/src/tests/flags_test.ts
+++ b/src/tests/flags_test.ts
@@ -1,8 +1,8 @@
 import { assertEquals } from "../dev_deps.ts";
-import { getStartHookAdditionalFlags } from "../flags.ts";
+import { getStartHookAdditionalDenoFlags } from "../flags.ts";
 
 Deno.test("getStartHookAdditionalFlags sets certificate validation flag, with =", () => {
-  const result = getStartHookAdditionalFlags([
+  const result = getStartHookAdditionalDenoFlags([
     "--sdk-unsafely-ignore-certificate-errors=https://dev1234.slack.com",
   ]);
   assertEquals(
@@ -12,7 +12,7 @@ Deno.test("getStartHookAdditionalFlags sets certificate validation flag, with ="
 });
 
 Deno.test("getStartHookAdditionalFlags sets certificate validation flag", () => {
-  const result = getStartHookAdditionalFlags([
+  const result = getStartHookAdditionalDenoFlags([
     "--sdk-unsafely-ignore-certificate-errors",
     "https://dev1234.slack.com",
   ]);
@@ -23,7 +23,7 @@ Deno.test("getStartHookAdditionalFlags sets certificate validation flag", () => 
 });
 
 Deno.test("getStartHookAdditionalFlags passes through empty flags", () => {
-  const result = getStartHookAdditionalFlags([]);
+  const result = getStartHookAdditionalDenoFlags([]);
   assertEquals(
     result,
     "",


### PR DESCRIPTION
###  Summary

Allows the CLI to pass in a flag `--sdk-unsafely-ignore-certificate-errors` to `get-hooks` to tell the SDK to pass the specific domain to Deno's `--unsafely-ignore-certificate-errors` flag in the `start` hook, so that it doesn't complain about SSL errors on numbered dev instances. 

Testing instructions:
* manually run the get-hooks hook with this new flag: `deno run -q --unstable --allow-read --allow-net <path to>/deno-slack-hooks/src/mod.ts --sdk-unsafely-ignore-certificate-errors=dev1234.slack.com`. Verify the start hook contains `--unsafely-ignore-certificate-errors=dev1234.slack.com` 

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/{project_slug}/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
