### PR TITLE
Updated hooks for builder 0.0.12

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.DS_Store
+.coverage

--- a/README.md
+++ b/README.md
@@ -8,13 +8,13 @@ units of functionality encapsulated as ephemeral functions. It implements the co
 
 If you find yourself needing to override a hook script specified by this library, you can do so in your Slack app's `/slack.json` file! Just specify a new script for the hook in question. The hooks currently provided by this repo that can be overridden are `build`, `start`, and `get-manifest`.
 
-Below is an example `/slack.json` file that overrides the `build` script to point to your local repo for development purposes.
+Below is an example `/slack.json` file that overrides the `build` script to point to your local repo for development purposes. It's using an implicit "latest" version of the https://deno.land/x/deno_slack_hooks/mod.ts script, but we suggest pinning it to whatever the latest version is.
 
 ```json
 {
   "hooks": {
-    "get-hooks": "deno run -q --unstable --allow-read --allow-net https://deno.land/x/deno_slack_hooks@0.0.5/mod.ts",
-    "build": "deno run -q --unstable --config=deno.jsonc --allow-read --allow-write --allow-net /<path-to-your-local-repo>/mod.ts"
+    "get-hooks": "deno run -q --allow-read --allow-net https://deno.land/x/deno_slack_hooks/mod.ts",
+    "build": "deno run -q --config=deno.jsonc --allow-read --allow-write --allow-net --allow-run /<path-to-your-local-repo>/mod.ts"
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -24,3 +24,7 @@ The [Slack CLI][cli] will automatically know to pick up your local hook definiti
 This can also be used to change the flags sent to the `deno run` command if you decide to change the location of your config file, or switch to an import map instead.
 
 [cli]: https://github.com/slackapi/slack-cli
+
+## Running Tests
+
+Tests can be run locally via `deno task test`. This will run unit tests as well as check formatting and linting.

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -1,0 +1,5 @@
+{
+  "tasks": {
+    "test": "deno test src && deno fmt --check src && deno lint src",
+  }
+}

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -1,6 +1,6 @@
 import { getStartHookAdditionalDenoFlags } from "./flags.ts";
 
-export const BUILDER_TAG = "deno_slack_builder@0.0.10";
+export const BUILDER_TAG = "deno_slack_builder@0.0.12";
 export const RUNTIME_TAG = "deno_slack_runtime@0.0.6";
 
 export const projectScripts = (args: string[]) => {
@@ -9,11 +9,11 @@ export const projectScripts = (args: string[]) => {
     "runtime": "deno",
     "hooks": {
       "get-manifest":
-        `deno run -q --unstable --config=deno.jsonc --allow-read --allow-net https://deno.land/x/${BUILDER_TAG}/mod.ts --manifest`,
+        `deno run -q --config=deno.jsonc --allow-read --allow-net https://deno.land/x/${BUILDER_TAG}/mod.ts --manifest`,
       "build":
-        `deno run -q --unstable --config=deno.jsonc --allow-read --allow-write --allow-net https://deno.land/x/${BUILDER_TAG}/mod.ts`,
+        `deno run -q --config=deno.jsonc --allow-read --allow-write --allow-net --allow-run  https://deno.land/x/${BUILDER_TAG}/mod.ts`,
       "start":
-        `deno run -q --unstable --config=deno.jsonc --allow-read --allow-net ${startHookFlags} https://deno.land/x/${RUNTIME_TAG}/local-run.ts`,
+        `deno run -q --config=deno.jsonc --allow-read --allow-net ${startHookFlags} https://deno.land/x/${RUNTIME_TAG}/local-run.ts`,
     },
     "config": {
       "watch": {


### PR DESCRIPTION
###  Summary

This updates the deno_slack_builder version used in the hooks to 0.0.12, which has changes that support Deno `v1.22.0` (accounting for `Deno.emit()` removal). I was also able to remove our inclusion of the `--unstable` flags in each of our hooks, as we're no longer using any unstable apis.

* We needed to add an allow-run flag to our build script now that it calls out to Deno.run when bundling.
* Also added a deno.jsonc w/ a test task to making running the tests/fmt/lint locally a bit easier.
* Updated the Readme to be version agnostic in it's example.

## Testing
Update a project's `slack.json` to point to a local version of these hooks. Notice we can also drop the `--unstable` flag here as well.

```
{
  "hooks": {
    "get-hooks": "deno run -q --allow-read --allow-net /Users/<your-path-to>/deno-slack-hooks/src/mod.ts"
  }
}

```

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/{project_slug}/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
