### PR TITLE
Bumping hooks version to 0.0.9

### DIFF
--- a/src/libraries.ts
+++ b/src/libraries.ts
@@ -7,7 +7,7 @@ export const DENO_SLACK_RUNTIME = "deno_slack_runtime";
 export const VERSIONS = {
   [DENO_SLACK_BUILDER]: "0.0.12",
   [DENO_SLACK_RUNTIME]: "0.0.6",
-  [DENO_SLACK_HOOKS]: "0.0.6",
+  [DENO_SLACK_HOOKS]: "0.0.9",
 };
 
 export const BUILDER_TAG = `${DENO_SLACK_BUILDER}@${


### PR DESCRIPTION
###  Summary

We need to make sure the git tags and the self-referential version in the code match, otherwise the response to the `get-hooks` hook will return older hook info.

Problem I just saw: right now if you use hooks v0.0.8 in a new deno-reverse-string app, and run `slack -v version` to trigger the `check-update` flow, because the self-referred hooks version is set to 0.0.6, but the git-tagged version of this repo is 0.0.8, the `check-update` flow will fail (because hooks v0.0.6 does not contain a `check-update` hook implementation).

# TODO

- [ ] Send a PR to bump the hooks version in the deno-reverse-string `slack.json` file