### PR TITLE
Adding get-trigger hook

### DIFF
--- a/src/create-trigger.ts
+++ b/src/create-trigger.ts
@@ -1,0 +1,52 @@
+import { parse, path } from "./deps.ts";
+
+const createTrigger = async () => {
+  const source = parse(Deno.args).source as string;
+
+  if (!source) throw new Error("A source path needs to be defined");
+
+  const fullPath = path.isAbsolute(source)
+    ? source
+    : path.join(Deno.cwd(), source || "");
+
+  return await readFile(fullPath);
+};
+
+const readFile = async (path: string) => {
+  try {
+    const { isFile } = await Deno.stat(path);
+    if (!isFile) throw new Error("The specified source is not a valid file.");
+    if (path.endsWith(".json")) return readJSONFile(path);
+    return readTSFile(path);
+  } catch (e) {
+    if (e instanceof Deno.errors.NotFound) {
+      throw new Error("Trigger Definition file cannot be found");
+    }
+    throw e;
+  }
+};
+
+const readJSONFile = async (path: string) => {
+  try {
+    const jsonString = await Deno.readTextFile(path);
+    return JSON.parse(jsonString);
+  } catch (e) {
+    throw e;
+  }
+};
+
+const readTSFile = async (path: string) => {
+  try {
+    const file = await import(`file://${path}`);
+    if (file && !file.default) {
+      throw new Error("The Trigger Definition isn't being exported by default");
+    }
+    return file;
+  } catch (e) {
+    throw e;
+  }
+};
+
+if (import.meta.main) {
+  console.log(JSON.stringify(await createTrigger()));
+}

--- a/src/create-trigger.ts
+++ b/src/create-trigger.ts
@@ -41,7 +41,7 @@ const readTSFile = async (path: string) => {
     if (file && !file.default) {
       throw new Error("The Trigger Definition isn't being exported by default");
     }
-    return file;
+    return file.default;
   } catch (e) {
     throw e;
   }

--- a/src/deps.ts
+++ b/src/deps.ts
@@ -1,1 +1,2 @@
 export { parse } from "https://deno.land/std@0.138.0/flags/mod.ts";
+export * as path from "https://deno.land/std@0.134.0/path/mod.ts";

--- a/src/get_trigger.ts
+++ b/src/get_trigger.ts
@@ -1,6 +1,6 @@
 import { parse, path } from "./deps.ts";
 
-const createTrigger = async () => {
+const getTrigger = async () => {
   const source = parse(Deno.args).source as string;
 
   if (!source) throw new Error("A source path needs to be defined");
@@ -48,5 +48,5 @@ const readTSFile = async (path: string) => {
 };
 
 if (import.meta.main) {
-  console.log(JSON.stringify(await createTrigger()));
+  console.log(JSON.stringify(await getTrigger()));
 }


### PR DESCRIPTION
###  Summary

@sopokuagyemang is working on adding a new hook to the CLI for trigger creation. While waiting on that, I have implemented this `get-trigger` hook that will accept a `json` file or a file with a default export, and log it to `stdout` for consumption.

#### Testing
You can either pull this down and run the script directly via
```bash
deno run --allow-read ./src/get-trigger.ts --source=your-trigger-file.json.
```

You can also run this directly by referencing the commit hash
```bash
deno run --allow-read https://raw.githubusercontent.com/slackapi/deno-slack-hooks/d9f93add46ccc39bda5aa8ad10a24c88524fcd6e/src/create-trigger.ts --source=your-trigger-file.ts
```

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/{project_slug}/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).