### PR TITLE
Add support for .jsonc files during check-update and install-update

### DIFF
--- a/src/check_update.ts
+++ b/src/check_update.ts
@@ -117,11 +117,11 @@ export async function readProjectDependencies(): Promise<VersionMap> {
  * as those dependency files referenced in deno.json or deno.jsonc, and returns
  * an array of arrays made up of filename and dependency key pairs.
  */
-export async function gatherDependencyFiles(cwd: string): Promise<string[][]> {
-  const dependencyFiles = [
-    ["import_map.json", "imports"],
+export async function gatherDependencyFiles(
+  cwd: string,
+): Promise<[string, "imports" | "hooks"][]> {
+  const dependencyFiles: [string, "imports" | "hooks"][] = [
     ["slack.json", "hooks"],
-    ["slack.jsonc", "hooks"],
   ];
 
   // Parse deno.* files for `importMap` dependency file

--- a/src/check_update.ts
+++ b/src/check_update.ts
@@ -3,8 +3,8 @@ import {
   DENO_SLACK_HOOKS,
   DENO_SLACK_SDK,
 } from "./libraries.ts";
-
-import { getJSON, JSONCValue } from "./utilities.ts";
+import { JSONValue } from "./deps.ts";
+import { getJSON } from "./utilities.ts";
 
 const IMPORT_MAP_SDKS = [DENO_SLACK_SDK, DENO_SLACK_API];
 const SLACK_JSON_SDKS = [
@@ -120,7 +120,6 @@ export async function readProjectDependencies(): Promise<VersionMap> {
 export async function gatherDependencyFiles(cwd: string): Promise<string[][]> {
   const dependencyFiles = [
     ["import_map.json", "imports"],
-    ["import_map.jsonc", "imports"],
     ["slack.json", "hooks"],
     ["slack.jsonc", "hooks"],
   ];
@@ -165,7 +164,7 @@ export async function getDenoImportMapFiles(
  * value pairs that make use of the dependencies.
  */
 export function extractDependencies(
-  json: JSONCValue,
+  json: JSONValue,
   key: string,
 ): [string, string][] {
   // Determine if the JSON passed is an object

--- a/src/deps.ts
+++ b/src/deps.ts
@@ -1,2 +1,3 @@
 export { parse } from "https://deno.land/std@0.138.0/flags/mod.ts";
 export * as path from "https://deno.land/std@0.134.0/path/mod.ts";
+export type { JSONValue } from "https://deno.land/std@0.149.0/encoding/jsonc.ts";

--- a/src/dev_deps.ts
+++ b/src/dev_deps.ts
@@ -3,6 +3,6 @@ export {
   assertRejects,
   assertStringIncludes,
 } from "https://deno.land/std@0.138.0/testing/asserts.ts";
-export * from "https://deno.land/x/mock_fetch@0.3.0/mod.ts";
+export * as mockFetch from "https://deno.land/x/mock_fetch@0.3.0/mod.ts";
 
 export * as mockFile from "https://deno.land/x/mock_file@v1.0.1/mod.ts";

--- a/src/install_update.ts
+++ b/src/install_update.ts
@@ -3,8 +3,9 @@ import {
   gatherDependencyFiles,
   Release,
 } from "./check_update.ts";
-import { getJSON, JSONCValue } from "./utilities.ts";
+import { getJSON } from "./utilities.ts";
 import { projectScripts } from "./mod.ts";
+import { JSONValue } from "./deps.ts";
 
 export const SDK_NAME = "the Slack SDK";
 
@@ -136,7 +137,7 @@ export async function updateDependencyFile(
  * an updated map of all dependencies, as well as an update summary of each.
  */
 export function updateDependencyMap(
-  dependencyMap: JSONCValue,
+  dependencyMap: JSONValue,
   releases: Release[],
 ) {
   const mapIsObject = dependencyMap && typeof dependencyMap === "object" &&

--- a/src/install_update.ts
+++ b/src/install_update.ts
@@ -79,14 +79,8 @@ export async function createUpdateResp(
     updateResp.error = { message: err.message };
   }
 
-  // Reduce the total updates returned by removing duplicates
-  updateResp.updates = updateResp.updates.reduce(
-    (existingUpdates: Update[], newUpdate) =>
-      existingUpdates.find((eu) => eu.name === newUpdate.name)
-        ? existingUpdates
-        : [...existingUpdates, newUpdate],
-    [],
-  );
+  // Pare down updates by removing duplicates
+  updateResp.updates = [...new Set(updateResp.updates)];
 
   return updateResp;
 }

--- a/src/install_update.ts
+++ b/src/install_update.ts
@@ -1,5 +1,9 @@
-import { checkForSDKUpdates, Release } from "./check_update.ts";
-import { getJSON } from "./utilities.ts";
+import {
+  checkForSDKUpdates,
+  gatherDependencyFiles,
+  Release,
+} from "./check_update.ts";
+import { getJSON, JSONCValue } from "./utilities.ts";
 import { projectScripts } from "./mod.ts";
 
 export const SDK_NAME = "the Slack SDK";
@@ -61,23 +65,27 @@ export async function createUpdateResp(
 
   try {
     const cwd = Deno.cwd();
+    const dependencyFiles = await gatherDependencyFiles(cwd);
+    let updateResponses: Update[] = [];
 
-    // Update import_map.json with latest dependency versions
-    const importsUpdateResp = await updateDependencyFile(
-      `${cwd}/import_map.json`,
-      releases,
-    );
-
-    // Update slack.json with latest dependency versions
-    const hooksUpdateResp = await updateDependencyFile(
-      `${cwd}/slack.json`,
-      releases,
-    );
-
-    updateResp.updates = [...importsUpdateResp, ...hooksUpdateResp];
+    for (const [file, _] of dependencyFiles) {
+      // Update dependency file with latest dependency versions
+      const updateResp = await updateDependencyFile(`${cwd}/${file}`, releases);
+      updateResponses = [...updateResponses, ...updateResp];
+    }
+    updateResp.updates = updateResponses;
   } catch (err) {
     updateResp.error = { message: err.message };
   }
+
+  // Reduce the total updates returned by removing duplicates
+  updateResp.updates = updateResp.updates.reduce(
+    (existingUpdates: Update[], newUpdate) =>
+      existingUpdates.find((eu) => eu.name === newUpdate.name)
+        ? existingUpdates
+        : [...existingUpdates, newUpdate],
+    [],
+  );
 
   return updateResp;
 }
@@ -92,25 +100,27 @@ export async function updateDependencyFile(
   releases: Release[],
 ): Promise<Update[]> {
   try {
-    const dependencyMap = await getJSON(path);
-    const { imports, hooks } = dependencyMap;
+    const dependencyJSON = await getJSON(path);
+    const isParsable = dependencyJSON && typeof dependencyJSON === "object" &&
+      !Array.isArray(dependencyJSON) &&
+      (dependencyJSON.imports || dependencyJSON.hooks);
 
-    // If file doesn't exist or expected dependency key is missing
-    if (!imports && !hooks) return [];
+    // If file doesn't exist, dependency key is missing or is of wrong type
+    if (!isParsable) return [];
 
-    const dependencyKey = imports ? "imports" : "hooks";
+    const dependencyKey = dependencyJSON.imports ? "imports" : "hooks";
 
     // Update only the dependency-related key in given file ("imports" or "hooks")
     const { updatedDependencies, updateSummary } = updateDependencyMap(
-      dependencyMap[dependencyKey],
+      dependencyJSON[dependencyKey],
       releases,
     );
 
     // Replace the dependency-related section with the updated version
-    dependencyMap[dependencyKey] = updatedDependencies;
+    dependencyJSON[dependencyKey] = updatedDependencies;
     await Deno.writeTextFile(
       path,
-      JSON.stringify(dependencyMap, null, 2).concat("\n"),
+      JSON.stringify(dependencyJSON, null, 2).concat("\n"),
     );
 
     return updateSummary;
@@ -126,10 +136,13 @@ export async function updateDependencyFile(
  * an updated map of all dependencies, as well as an update summary of each.
  */
 export function updateDependencyMap(
-  dependencyMap: { [key: string]: string },
+  dependencyMap: JSONCValue,
   releases: Release[],
 ) {
-  const updatedDependencies: { [key: string]: string } = { ...dependencyMap };
+  const mapIsObject = dependencyMap && typeof dependencyMap === "object" &&
+    !Array.isArray(dependencyMap);
+
+  const updatedDependencies = mapIsObject ? { ...dependencyMap } : {};
   const updateSummary: Update[] = [];
 
   // Loop over key, val pairs of 'imports' or 'hooks', depending on file provided
@@ -137,11 +150,8 @@ export function updateDependencyMap(
     for (const { name, current, latest } of releases) {
       // If the dependency matches an available release,
       // and an update is available, replace the version
-      if (current && latest && val.includes(name)) {
-        updatedDependencies[key] = updatedDependencies[key].replace(
-          current,
-          latest,
-        );
+      if (current && latest && typeof val === "string" && val.includes(name)) {
+        updatedDependencies[key] = val.replace(current, latest);
         updateSummary.push({
           name,
           previous: current,

--- a/src/tests/check_update_test.ts
+++ b/src/tests/check_update_test.ts
@@ -1,8 +1,166 @@
 import { assertEquals, assertRejects } from "../dev_deps.ts";
-import * as mf from "../dev_deps.ts";
-import { extractVersion, fetchLatestModuleVersion } from "../check_update.ts";
+import { mockFetch, mockFile } from "../dev_deps.ts";
+import {
+  extractDependencies,
+  extractVersion,
+  fetchLatestModuleVersion,
+  getDenoImportMapFiles,
+  readProjectDependencies,
+} from "../check_update.ts";
+
+const MOCK_SLACK_JSON = JSON.stringify({
+  hooks: {
+    "get-hooks":
+      "deno run -q --allow-read --allow-net https://deno.land/x/deno_slack_hooks@0.0.9/mod.ts",
+  },
+});
+
+const MOCK_IMPORT_MAP_JSON = JSON.stringify({
+  imports: {
+    "deno-slack-sdk/": "https://deno.land/x/deno_slack_sdk@0.0.6/",
+    "deno-slack-api/": "https://deno.land/x/deno_slack_api@0.0.6/",
+  },
+});
+
+const MOCK_DENO_JSON = JSON.stringify({
+  importMap: "custom_import_map.json",
+});
+
+const MOCK_SLACK_JSON_FILE = new TextEncoder().encode(MOCK_SLACK_JSON);
+const MOCK_IMPORT_MAP_FILE = new TextEncoder().encode(MOCK_IMPORT_MAP_JSON);
+const MOCK_DENO_JSON_FILE = new TextEncoder().encode(MOCK_DENO_JSON);
 
 Deno.test("check-update hook tests", async (t) => {
+  // readProjectDependencies
+  await t.step("readProjectDependencies method", async (evT) => {
+    await evT.step(
+      "if dependency file contains recnognized dependency, version appears in returned map",
+      async () => {
+        mockFile.prepareVirtualFile("./import_map.json", MOCK_IMPORT_MAP_FILE);
+        mockFile.prepareVirtualFile("./slack.json", MOCK_SLACK_JSON_FILE);
+
+        const actual = await readProjectDependencies();
+
+        // Expected dependencies are present in returned versionMap
+        assertEquals(
+          true,
+          "deno_slack_hooks" in actual &&
+            "deno_slack_api" in actual &&
+            "deno_slack_hooks" in actual,
+          "slack.json dependency wasn't found in returned versionMap",
+        );
+
+        // Initial expected versionMap properties are present (name, current)
+        assertEquals(
+          true,
+          Object.values(actual).every((dep) => dep.name && dep.current),
+          "slack.json dependency wasn't found in returned versionMap",
+        );
+      },
+    );
+  });
+
+  // getDenoImportMapFiles
+  await t.step("getDenoImportMapFiles method", async (evT) => {
+    await evT.step(
+      "if deno.json file is available, or no importMap key is present, an empty array is returned",
+      async () => {
+        const cwd = Deno.cwd();
+        const actual = await getDenoImportMapFiles(cwd);
+        const expected: [string, "imports"][] = [];
+
+        assertEquals(
+          actual,
+          expected,
+          `Expected: ${JSON.stringify(expected)}\n Actual: ${
+            JSON.stringify(actual)
+          }`,
+        );
+      },
+    );
+
+    await evT.step(
+      "if deno.json file is available, the correct filename + dependency key pair is returned",
+      async () => {
+        const cwd = Deno.cwd();
+        mockFile.prepareVirtualFile("./deno.json", MOCK_DENO_JSON_FILE);
+
+        const actual = await getDenoImportMapFiles(cwd);
+
+        // Correct custom importMap file name is returned
+        assertEquals(
+          actual,
+          [["custom_import_map.json", "imports"]],
+          "correct importMap key value wasn't returned",
+        );
+      },
+    );
+  });
+
+  // extractDependencies
+  await t.step("extractDependencies method", async (evT) => {
+    await evT.step(
+      "given import_map.json or slack.json file contents, an array of key, value dependency pairs is returned",
+      async () => {
+        const importMapActual = await extractDependencies(
+          JSON.parse(MOCK_IMPORT_MAP_JSON),
+          "imports",
+        );
+
+        const slackHooksActual = await extractDependencies(
+          JSON.parse(MOCK_SLACK_JSON),
+          "hooks",
+        );
+
+        const importMapExpected: [string, string][] = [[
+          "deno-slack-sdk/",
+          "https://deno.land/x/deno_slack_sdk@0.0.6/",
+        ], ["deno-slack-api/", "https://deno.land/x/deno_slack_api@0.0.6/"]];
+
+        const slackHooksExpected: [string, string][] = [
+          [
+            "get-hooks",
+            "deno run -q --allow-read --allow-net https://deno.land/x/deno_slack_hooks@0.0.9/mod.ts",
+          ],
+        ];
+
+        assertEquals(
+          importMapActual,
+          importMapExpected,
+          `Expected: ${JSON.stringify([])}\n Actual: ${
+            JSON.stringify(importMapActual)
+          }`,
+        );
+
+        assertEquals(
+          slackHooksActual,
+          slackHooksExpected,
+          `Expected: ${JSON.stringify([])}\n Actual: ${
+            JSON.stringify(importMapActual)
+          }`,
+        );
+      },
+    );
+
+    await evT.step(
+      "if deno.json file is available, the correct filename + dependency key pair is returned",
+      async () => {
+        const cwd = Deno.cwd();
+        mockFile.prepareVirtualFile("./deno.json", MOCK_DENO_JSON_FILE);
+
+        const actual = await getDenoImportMapFiles(cwd);
+
+        // Correct custom importMap file name is returned
+        assertEquals(
+          actual,
+          [["custom_import_map.json", "imports"]],
+          "correct importMap key value wasn't returned",
+        );
+      },
+    );
+  });
+
+  // extractVersion
   await t.step("extractVersion method", async (evT) => {
     await evT.step(
       "if version string does not contain an '@' then return empty",
@@ -37,12 +195,14 @@ Deno.test("check-update hook tests", async (t) => {
       },
     );
   });
+
+  // fetchLatestModuleVersion
   await t.step("fetchLatestModuleVersion method", async (evT) => {
-    mf.install(); // mock out calls to fetch
+    mockFetch.install(); // mock out calls to fetch
     await evT.step(
       "should throw if location header is not returned",
       async () => {
-        mf.mock("GET@/x/slack", (_req: Request) => {
+        mockFetch.mock("GET@/x/slack", (_req: Request) => {
           return new Response(null, { headers: {} });
         });
         await assertRejects(async () => {
@@ -53,7 +213,7 @@ Deno.test("check-update hook tests", async (t) => {
     await evT.step(
       "should return version extracted from location header",
       async () => {
-        mf.mock("GET@/x/slack", (_req: Request) => {
+        mockFetch.mock("GET@/x/slack", (_req: Request) => {
           return new Response(null, {
             headers: { location: "/x/slack@0.1.1" },
           });
@@ -62,6 +222,6 @@ Deno.test("check-update hook tests", async (t) => {
         assertEquals(version, "0.1.1", "inocrrect version returned");
       },
     );
-    mf.uninstall();
+    mockFetch.uninstall();
   });
 });

--- a/src/tests/install_update_test.ts
+++ b/src/tests/install_update_test.ts
@@ -48,8 +48,13 @@ const MOCK_IMPORT_MAP_JSON = JSON.stringify({
   },
 });
 
+const MOCK_DENO_JSON = JSON.stringify({
+  "importMap": "import_map.json",
+});
+
 const MOCK_SLACK_JSON_FILE = new TextEncoder().encode(MOCK_SLACK_JSON);
 const MOCK_IMPORT_MAP_FILE = new TextEncoder().encode(MOCK_IMPORT_MAP_JSON);
+const MOCK_DENO_JSON_FILE = new TextEncoder().encode(MOCK_DENO_JSON);
 
 Deno.test("update hook tests", async (t) => {
   await t.step("createUpdateResp", async (evT) => {
@@ -73,10 +78,11 @@ Deno.test("update hook tests", async (t) => {
     );
 
     await evT.step(
-      "if import_map.json has available updates, then response includes those updates",
+      "if referenced importMap in deno.json has available updates, then response includes those updates",
       async () => {
-        mockFile.prepareVirtualFile("./import_map.json", MOCK_IMPORT_MAP_FILE);
         mockFile.prepareVirtualFile("./slack.json", MOCK_SLACK_JSON_FILE);
+        mockFile.prepareVirtualFile("./deno.json", MOCK_DENO_JSON_FILE);
+        mockFile.prepareVirtualFile("./import_map.json", MOCK_IMPORT_MAP_FILE);
 
         const expectedHooksUpdateSummary = [{
           name: "deno_slack_hooks",
@@ -101,8 +107,8 @@ Deno.test("update hook tests", async (t) => {
         const expected = {
           name: SDK_NAME,
           updates: [
-            ...expectedImportsUpdateSummary,
             ...expectedHooksUpdateSummary,
+            ...expectedImportsUpdateSummary,
           ],
         };
 

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -1,16 +1,27 @@
+import {
+  JSONValue,
+  parse,
+} from "https://deno.land/std@0.149.0/encoding/jsonc.ts";
+
+// Export alias to avoid having to import the above elsewhere
+export type JSONCValue = JSONValue;
+
 /**
  * getJSON attempts to read the given file. If successful,
- * it returns an object of the contained JSON. If the extraction
+ * it returns the contents of the file. If the extraction
  * fails, it returns an empty object.
  */
-export async function getJSON(file: string) {
+export async function getJSON(file: string): Promise<JSONCValue> {
   try {
-    return JSON.parse(await Deno.readTextFile(file));
-  } catch (_) {
-    // TODO :: This needs to be updated to bubble up the case
-    // where the file doesn't exist. Doing so requires
-    // refactoring `check-update` and `install-update`
-    // to accommodate the adjustment.
+    const fileContents = await Deno.readTextFile(file);
+    return parse(fileContents);
+  } catch (err) {
+    if (err instanceof Deno.errors.NotFound) {
+      // TODO :: This needs to be updated to bubble up the case
+      // where the file doesn't exist. Doing so requires
+      // refactoring `check-update` and `install-update`
+      // to accommodate the adjustment.
+    }
     return {};
   }
 }

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -1,17 +1,11 @@
-import {
-  JSONValue,
-  parse,
-} from "https://deno.land/std@0.149.0/encoding/jsonc.ts";
-
-// Export alias to avoid having to import the above elsewhere
-export type JSONCValue = JSONValue;
-
+import { parse } from "https://deno.land/std@0.149.0/encoding/jsonc.ts";
+import { JSONValue } from "./deps.ts";
 /**
  * getJSON attempts to read the given file. If successful,
  * it returns the contents of the file. If the extraction
  * fails, it returns an empty object.
  */
-export async function getJSON(file: string): Promise<JSONCValue> {
+export async function getJSON(file: string): Promise<JSONValue> {
   try {
     const fileContents = await Deno.readTextFile(file);
     return parse(fileContents);


### PR DESCRIPTION
###  Summary

This PR adds support for parsing `.jsonc` files (in addition to `.json`) that might be encountered when checking for and installing dependency updates. Also added support for `deno.*` configuration files.

**A special note because I'm not excessively type-checking here just for my sake:**
- Making use of Deno's standard library `parse` function created some.. interesting hoops to jump through. Specifically, the return value is a `JSONValue` which can be _almost_ anything but not quite. As such, its inclusion has required a lot of inconvenient checks to verify that the shape being dealt with is kosher. See all of those `isParsable`? Fun times.

### Testing Steps
After each of the following scenarios,  run `hermes update` and verify that you can see the updates, and, when subsequently auto-updating, that the expected diff is present when you run `git diff`:

- **Happy Path**. Make sure you have downgraded some dependencies in `slack.json` and `import_map.json`. 
- **Remix**. Turn your `import_map.json` to `import_map.jsonc`. Maybe you add comments, maybe you don't. The world is your oyster.
- **Wild West**. Introduce a `deno.json` or `deno.jsonc` (or both, you rebel), setting one or both `importMap` keys to point to another file whose contents resemble `import_map.json`. You can call this file whatever you like, but just make sure it has an `imports` key and contains dependencies.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/{project_slug}/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
