### PR TITLE
Raise, handle, and relay errors that occur when accessing dependency files

### DIFF
--- a/src/check_update.ts
+++ b/src/check_update.ts
@@ -142,6 +142,7 @@ export async function gatherDependencyFiles(
 > {
   const dependencyFiles: [string, "imports" | "hooks"][] = [
     ["slack.json", "hooks"],
+    ["slack.jsonc", "hooks"],
   ];
 
   // Parse deno.* files for `importMap` dependency file

--- a/src/check_update.ts
+++ b/src/check_update.ts
@@ -141,7 +141,6 @@ export async function gatherDependencyFiles(
   }
 > {
   const dependencyFiles: [string, "imports" | "hooks"][] = [
-    ["import_map.json", "imports"],
     ["slack.json", "hooks"],
   ];
 

--- a/src/check_update.ts
+++ b/src/check_update.ts
@@ -142,7 +142,6 @@ export async function gatherDependencyFiles(
 > {
   const dependencyFiles: [string, "imports" | "hooks"][] = [
     ["import_map.json", "imports"],
-    ["import_map.jsonc", "imports"],
     ["slack.json", "hooks"],
   ];
 

--- a/src/install_update.ts
+++ b/src/install_update.ts
@@ -67,15 +67,20 @@ export async function createUpdateResp(
   try {
     const cwd = Deno.cwd();
     const { dependencyFiles } = await gatherDependencyFiles(cwd);
-    // const updateResponses: Update[] = [];
 
     for (const [file, _] of dependencyFiles) {
       // Update dependency file with latest dependency versions
-      const fileUpdateResp = await updateDependencyFile(
-        `${cwd}/${file}`,
-        releases,
-      );
-      updateResp.updates = [...updateResp.updates, ...fileUpdateResp];
+      try {
+        const fileUpdateResp = await updateDependencyFile(
+          `${cwd}/${file}`,
+          releases,
+        );
+        updateResp.updates = [...updateResp.updates, ...fileUpdateResp];
+      } catch (err) {
+        updateResp.error = updateResp.error
+          ? { message: updateResp.error.message += `\n   ${err.message}` }
+          : { message: err.message };
+      }
     }
   } catch (err) {
     updateResp.error = { message: err.message };

--- a/src/install_update.ts
+++ b/src/install_update.ts
@@ -127,8 +127,10 @@ export async function updateDependencyFile(
 
     return updateSummary;
   } catch (err) {
-    throw new Error(err);
+    if (!(err.cause instanceof Deno.errors.NotFound)) throw err;
   }
+
+  return [];
 }
 
 /**

--- a/src/install_update.ts
+++ b/src/install_update.ts
@@ -66,15 +66,17 @@ export async function createUpdateResp(
 
   try {
     const cwd = Deno.cwd();
-    const dependencyFiles = await gatherDependencyFiles(cwd);
-    let updateResponses: Update[] = [];
+    const { dependencyFiles } = await gatherDependencyFiles(cwd);
+    // const updateResponses: Update[] = [];
 
     for (const [file, _] of dependencyFiles) {
       // Update dependency file with latest dependency versions
-      const updateResp = await updateDependencyFile(`${cwd}/${file}`, releases);
-      updateResponses = [...updateResponses, ...updateResp];
+      const fileUpdateResp = await updateDependencyFile(
+        `${cwd}/${file}`,
+        releases,
+      );
+      updateResp.updates = [...updateResp.updates, ...fileUpdateResp];
     }
-    updateResp.updates = updateResponses;
   } catch (err) {
     updateResp.error = { message: err.message };
   }

--- a/src/tests/check_update_test.ts
+++ b/src/tests/check_update_test.ts
@@ -50,7 +50,7 @@ Deno.test("check-update hook tests", async (t) => {
           true,
           "deno_slack_hooks" in versionMap &&
             "deno_slack_api" in versionMap &&
-            "deno_slack_hooks" in versionMap
+            "deno_slack_hooks" in versionMap,
         );
 
         // Initial expected versionMap properties are present (name, current)

--- a/src/tests/check_update_test.ts
+++ b/src/tests/check_update_test.ts
@@ -1,10 +1,13 @@
 import { assertEquals, assertRejects } from "../dev_deps.ts";
 import { mockFetch, mockFile } from "../dev_deps.ts";
 import {
+  createFileErrorMsg,
+  createUpdateResp,
   extractDependencies,
   extractVersion,
   fetchLatestModuleVersion,
   getDenoImportMapFiles,
+  hasBreakingChange,
   readProjectDependencies,
 } from "../check_update.ts";
 
@@ -40,20 +43,20 @@ Deno.test("check-update hook tests", async (t) => {
         mockFile.prepareVirtualFile("./deno.json", MOCK_DENO_JSON_FILE);
         mockFile.prepareVirtualFile("./import_map.json", MOCK_IMPORT_MAP_FILE);
 
-        const actual = await readProjectDependencies();
+        const { versionMap } = await readProjectDependencies();
 
         // Expected dependencies are present in returned versionMap
         assertEquals(
           true,
-          "deno_slack_hooks" in actual &&
-            "deno_slack_api" in actual &&
-            "deno_slack_hooks" in actual,
+          "deno_slack_hooks" in versionMap &&
+            "deno_slack_api" in versionMap &&
+            "deno_slack_hooks" in versionMap
         );
 
         // Initial expected versionMap properties are present (name, current)
         assertEquals(
           true,
-          Object.values(actual).every((dep) => dep.name && dep.current),
+          Object.values(versionMap).every((dep) => dep.name && dep.current),
           "slack.json dependency wasn't found in returned versionMap",
         );
       },
@@ -72,14 +75,14 @@ Deno.test("check-update hook tests", async (t) => {
         );
 
         const cwd = Deno.cwd();
-        const actual = await getDenoImportMapFiles(cwd);
-        const expected: [string, "imports" | "hooks"][] = [];
+        const { denoJSONDepFiles } = await getDenoImportMapFiles(cwd);
+        const expected: [string, "imports"][] = [];
 
         assertEquals(
-          actual,
+          denoJSONDepFiles,
           expected,
           `Expected: ${JSON.stringify(expected)}\n Actual: ${
-            JSON.stringify(actual)
+            JSON.stringify(denoJSONDepFiles)
           }`,
         );
       },
@@ -91,11 +94,11 @@ Deno.test("check-update hook tests", async (t) => {
         const cwd = Deno.cwd();
         mockFile.prepareVirtualFile("./deno.json", MOCK_DENO_JSON_FILE);
 
-        const actual = await getDenoImportMapFiles(cwd);
+        const { denoJSONDepFiles } = await getDenoImportMapFiles(cwd);
 
         // Correct custom importMap file name is returned
         assertEquals(
-          actual,
+          denoJSONDepFiles,
           [["import_map.json", "imports"]],
         );
       },
@@ -184,6 +187,27 @@ Deno.test("check-update hook tests", async (t) => {
     );
   });
 
+  // hasBreakingChange
+  await t.step("hasBreakingChange method", async (evT) => {
+    await evT.step(
+      "should return true if version difference is 1.0.0 or greater",
+      () => {
+        const currentVersion = "1.0.0";
+        const latestVersion = "2.0.0";
+        assertEquals(hasBreakingChange(currentVersion, latestVersion), true);
+      },
+    );
+
+    await evT.step(
+      "should return false if version difference is 1.0.0 or less",
+      () => {
+        const currentVersion = "1.0.0";
+        const latestVersion = "1.5.0";
+        assertEquals(hasBreakingChange(currentVersion, latestVersion), false);
+      },
+    );
+  });
+
   // fetchLatestModuleVersion
   await t.step("fetchLatestModuleVersion method", async (evT) => {
     mockFetch.install(); // mock out calls to fetch
@@ -211,5 +235,74 @@ Deno.test("check-update hook tests", async (t) => {
       },
     );
     mockFetch.uninstall();
+  });
+
+  // createUpdateResp
+  await t.step("createUpdateResp method", async (evT) => {
+    await evT.step(
+      "response should include errors if there are inaccessible files found",
+      () => {
+        const error = new Error("test", {
+          cause: new Deno.errors.PermissionDenied(),
+        });
+        const versionMap = {};
+        const inaccessibleFiles = [{ name: "import_map.json", error }];
+        const updateResp = createUpdateResp(versionMap, inaccessibleFiles);
+
+        assertEquals(
+          updateResp.error &&
+            updateResp.error.message.includes("import_map.json"),
+          true,
+        );
+      },
+    );
+
+    await evT.step(
+      "response should not include errors if they are of type NotFound",
+      () => {
+        const error = new Error("test", {
+          cause: new Deno.errors.NotFound(),
+        });
+        const versionMap = {};
+        const inaccessibleFiles = [{ name: "import_map.json", error }];
+        const updateResp = createUpdateResp(versionMap, inaccessibleFiles);
+
+        assertEquals(!updateResp.error, true);
+      },
+    );
+  });
+
+  // createFileErrorMsg
+  await t.step("createFileErrorMsg method", async (evT) => {
+    await evT.step(
+      "message should not include errors if they're instance of NotFound",
+      () => {
+        const error = new Error("test", {
+          cause: new Deno.errors.NotFound(),
+        });
+        const inaccessibleFiles = [{ name: "import_map.json", error }];
+        const errorMsg = createFileErrorMsg(inaccessibleFiles);
+        assertEquals(errorMsg, "");
+      },
+    );
+
+    await evT.step(
+      "message should include errors if they're not instances of NotFound",
+      () => {
+        const notFoundError = new Error("test", {
+          cause: new Deno.errors.NotFound(),
+        });
+        const permissionError = new Error("test", {
+          cause: new Deno.errors.PermissionDenied(),
+        });
+        const inaccessibleFiles = [
+          { name: "import_map.json", error: notFoundError },
+          { name: "slack.json", error: permissionError },
+        ];
+        const errorMsg = createFileErrorMsg(inaccessibleFiles);
+        assertEquals(true, !errorMsg.includes("import_map.json"));
+        assertEquals(true, errorMsg.includes("slack.json"));
+      },
+    );
   });
 });

--- a/src/tests/install_update_test.ts
+++ b/src/tests/install_update_test.ts
@@ -59,7 +59,7 @@ const MOCK_DENO_JSON_FILE = new TextEncoder().encode(MOCK_DENO_JSON);
 Deno.test("update hook tests", async (t) => {
   await t.step("createUpdateResp", async (evT) => {
     await evT.step(
-      "if import_map.json and slack.json are not found, then response is an empty array",
+      "if dependency files are not found, response does not include an error",
       async () => {
         // Absence of prepareVirtualFile ensures that file does not exist
         // NOTE: *must* go before .prepareVirtualFile-dependent tests below until

--- a/src/tests/install_update_test.ts
+++ b/src/tests/install_update_test.ts
@@ -67,13 +67,7 @@ Deno.test("update hook tests", async (t) => {
         const actual = await createUpdateResp(MOCK_RELEASES);
         const expected = { name: SDK_NAME, updates: [] };
 
-        assertEquals(
-          actual,
-          expected,
-          `Expected: ${JSON.stringify(expected)}\n Actual: ${
-            JSON.stringify(actual)
-          }`,
-        );
+        assertEquals(actual, expected);
       },
     );
 
@@ -112,13 +106,7 @@ Deno.test("update hook tests", async (t) => {
           ],
         };
 
-        assertEquals(
-          actual,
-          expected,
-          `Expected: ${JSON.stringify(expected)}\n Actual: ${
-            JSON.stringify(actual)
-          }`,
-        );
+        assertEquals(actual, expected);
       },
     );
   });
@@ -161,13 +149,11 @@ Deno.test("update hook tests", async (t) => {
         assertEquals(
           await updateDependencyFile("./slack.json", MOCK_RELEASES),
           expectedHooksUpdateResp,
-          "correct dependency update response for slack.json was not returned",
         );
 
         assertEquals(
           await updateDependencyFile("./import_map.json", MOCK_RELEASES),
           expectedImportsUpdateResp,
-          "correct dependency update response for import_map.json was not returned",
         );
       },
     );

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -10,12 +10,6 @@ export async function getJSON(file: string): Promise<JSONValue> {
     const fileContents = await Deno.readTextFile(file);
     return parse(fileContents);
   } catch (err) {
-    // If supported dependency file was not found, return silent failure.
-    // The reason for this is that there may be any combination of supported
-    // dependency files used. The only case where bubbling this up would apply
-    // is if *no* dependency files were found, which, since slack.json is both
-    // necessary for the project AND a dependency file, is not a valid use case.
-    if (err instanceof Deno.errors.NotFound) return {};
     throw new Error(err.message, { cause: err });
   }
 }

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -10,12 +10,12 @@ export async function getJSON(file: string): Promise<JSONValue> {
     const fileContents = await Deno.readTextFile(file);
     return parse(fileContents);
   } catch (err) {
-    if (err instanceof Deno.errors.NotFound) {
-      // TODO :: This needs to be updated to bubble up the case
-      // where the file doesn't exist. Doing so requires
-      // refactoring `check-update` and `install-update`
-      // to accommodate the adjustment.
-    }
-    return {};
+    // If supported dependency file was not found, return silent failure.
+    // The reason for this is that there may be any combination of supported
+    // dependency files used. The only case where bubbling this up would apply
+    // is if *no* dependency files were found, which, since slack.json is both
+    // necessary for the project AND a dependency file, is not a valid use case.
+    if (err instanceof Deno.errors.NotFound) return {};
+    throw new Error(err.message, { cause: err });
   }
 }


### PR DESCRIPTION
###  Summary

This PR makes several changes to `check_update`, `install_update` and the `getJSON` utility function to enable the raising, handling, and relaying of errors that occur when accessing dependency files.

#### Partial failure (updates + inaccessible file)
https://user-images.githubusercontent.com/7788242/182486018-4f6661c0-ab4c-41e8-8c62-687f804730ac.mov


#### Total failure (no updates)
https://user-images.githubusercontent.com/7788242/182486057-d33a1c6f-c20b-4ad9-b05f-a7d854a14096.mov

#### Multiple (unrelated) things went wrong (chaos mode)
https://user-images.githubusercontent.com/7788242/182487045-871fa707-7f33-4fcc-9d5c-2308cfb1929d.mov


### Testing Steps
After each of the following scenarios,  run `hermes update` and verify that you can see the expected output:

- **Happy Path**. Downgraded some dependencies in `slack.json` and `import_map.json`. Verify that no errors are surfaced.
- **Missing Files**. Rename your `import_map.json` to something unsupported (e.g., `_import_map.json`). Verify that an error is not surfaced when a file is unable to be located.
- **Change Permissions**. Change the permissions on `import_map.json` (or any other supported dependency file -- the more, the better) to disallow access. Verify that an error is surfaced that indicates `PermissionDenied` for the affected files.
- **Downgrade + Change Permissions (Partial Update)** Repeat the above _Change Permissions_ scenario, but also downgrade some of your dependencies in a file you retain access to. Verify that you see the updated file(s) listed in the update message, but also see the `PermissionDenied` error, as well.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/{project_slug}/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).