### PR TITLE
Add script usage to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ Any invocations of this library require the `--allow-read` and `--allow-net` [de
 ## Supported Scripts
 The hooks currently provided by this repo are `build`, `start`, `check-update`, `install-update`, `get-trigger`, and `get-manifest`.
 
-| Hook Name         | CLI Command         | Description                     |
-| ----------------- | ------------------- | ------------------------------- |
+| Hook Name         | CLI Command            | Description                     |
+| ----------------- | ---------------------- | ------------------------------- |
 | `build`           | `slack deploy`         | Bundles any functions with Deno into an output directory that's compatible with the Run on Slack runtime. For more information, see the [deno-slack-builder](https://github.com/slackapi/deno-slack-builder) repository. |
 | `check-update`    | `slack upgrade`        | Checks the App's SDK dependencies to determine whether or not any of your libraries need to be updated. |
 | `get-manifest`    | `slack manifest`       | Converts a `manifest.json`, `manifest.js`, or `manifest.ts` file int o a valid manifest JSON payload. For more information, see the [deno-slack-builder](https://github.com/slackapi/deno-slack-builder) repository's `--manifest` arg. |

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The hooks currently provided by this repo are `build`, `start`, `check-update`, 
 | `get-hooks`       | N/A                    | Fetches the list of available hooks for the CLI from this repository. |
 | `get-trigger`     | `slack trigger create` | Converts a specified `json`, `js`, or `ts` file into a valid trigger JSON payload to be uploaded by the CLI to the `workflows.triggers.create` Slack API endpoint. |
 | `install-update`  | `slack upgrade`        | Prompts the user to automatically update any dependencies that need to be updated based on the result of the `check-update` hook. |
-| `start`           | `slack run`            | Creates a socket connection between the Slack CLI and a Slack workspace for local development that includes hot reloading. For more information, see the [deno-slack-runtime](https://github.com/slackapi/deno-slack-runtime) repository's details on `local-run`. |
+| `start`           | `slack run`            | While developing and locally running a deno-slack-based application, the CLI manages a socket connection with Slack's backend and delegates to this hook for invoking the correct application function for relevant events incoming via this connection. For more information, see the [deno-slack-runtime](https://github.com/slackapi/deno-slack-runtime) repository's details on `local-run`. |
 
 
 ### Check Update Script Usage

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The `check_update.ts` file is executed as a Deno program and takes no arguments.
 deno run -q --config=deno.jsonc --allow-read --allow-net https://deno.land/x/deno_slack_hooks/check_update.ts
 ```
 ### Get Hooks Script Usage
-The `mod.ts` file is executed as a Deno program and takes one no arguments
+The `mod.ts` file is executed as a Deno program and takes no arguments.
 
 #### Example
 ```bash

--- a/README.md
+++ b/README.md
@@ -10,9 +10,22 @@ This library requires a recent (at least 1.22) version of [deno](https://deno.la
 
 Any invocations of this library require the `--allow-read` and `--allow-net` [deno permissions](https://deno.land/manual/getting_started/permissions).
 
+## Supported Scripts
+The hooks currently provided by this repo are `build`, `start`, `check-update`, `install-update`, `get-trigger`, and `get-manifest`.
+
+| Hook Name         | CLI Command         | Description                     |
+| ----------------- | ------------------- | ------------------------------- |
+| `build`           | `slack deploy`         | Bundles any functions with Deno into an output directory that's compatible with the Run on Slack runtime. For more information, see the [deno-slack-builder](https://github.com/slackapi/deno-slack-builder) repository. |
+| `check-update`    | `slack upgrade`        | Checks the App's SDK dependencies to determine whether or not any of your libraries need to be updated. |
+| `get-manifest`    | `slack manifest`       | Converts a `manifest.json`, `manifest.js`, or `manifest.ts` file int o a valid manifest JSON payload. For more information, see the [deno-slack-builder](https://github.com/slackapi/deno-slack-builder) repository's `--manifest` arg. |
+| `get-trigger`     | `slack trigger create` | Converts a specified `json`, `js`, or `ts` file into a valid trigger JSON payload to be uploaded by the CLI to the `workflows.triggers.create` Slack API endpoint.|
+| `install-update`  | `slack upgrade`        | Prompts the user to automatically update any dependencies that need to be updated based on the result of the `check-update` hook. |
+| `start`           | `slack run`            | Creates a socket connection between the Slack CLI and a Slack workspace for local development that includes hot reloading. For more information, see the [deno-slack-runtime](https://github.com/slackapi/deno-slack-runtime) repository's details on `local-run`. |
+
+
 ## Script Overrides
 
-If you find yourself needing to override a hook script specified by this library, you can do so in your Slack app's `/slack.json` file! Just specify a new script for the hook in question. The hooks currently provided by this repo that can be overridden are `build`, `start`, and `get-manifest`.
+If you find yourself needing to override a hook script specified by this library, you can do so in your Slack app's `/slack.json` file! Just specify a new script for the hook in question. All supported hooks can be overwritten.
 
 Below is an example `/slack.json` file that overrides the `build` script to point to your local repo for development purposes. It's using an implicit "latest" version of the https://deno.land/x/deno_slack_hooks/mod.ts script, but we suggest pinning it to whatever the latest version is.
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ The hooks currently provided by this repo are `build`, `start`, `check-update`, 
 | `build`           | `slack deploy`         | Bundles any functions with Deno into an output directory that's compatible with the Run on Slack runtime. For more information, see the [deno-slack-builder](https://github.com/slackapi/deno-slack-builder) repository. |
 | `check-update`    | `slack upgrade`        | Checks the App's SDK dependencies to determine whether or not any of your libraries need to be updated. |
 | `get-manifest`    | `slack manifest`       | Converts a `manifest.json`, `manifest.js`, or `manifest.ts` file int o a valid manifest JSON payload. For more information, see the [deno-slack-builder](https://github.com/slackapi/deno-slack-builder) repository's `--manifest` arg. |
-| `get-trigger`     | `slack trigger create` | Converts a specified `json`, `js`, or `ts` file into a valid trigger JSON payload to be uploaded by the CLI to the `workflows.triggers.create` Slack API endpoint.|
+| `get-hooks`       | N/A                    | Fetches the list of available hooks for the CLI from this repository. |
+| `get-trigger`     | `slack trigger create` | Converts a specified `json`, `js`, or `ts` file into a valid trigger JSON payload to be uploaded by the CLI to the `workflows.triggers.create` Slack API endpoint. |
 | `install-update`  | `slack upgrade`        | Prompts the user to automatically update any dependencies that need to be updated based on the result of the `check-update` hook. |
 | `start`           | `slack run`            | Creates a socket connection between the Slack CLI and a Slack workspace for local development that includes hot reloading. For more information, see the [deno-slack-runtime](https://github.com/slackapi/deno-slack-runtime) repository's details on `local-run`. |
 
@@ -29,6 +30,13 @@ The `check_update.ts` file is executed as a Deno program and takes no arguments.
 #### Example
 ```bash
 deno run -q --config=deno.jsonc --allow-read --allow-net https://deno.land/x/deno_slack_hooks/check_update.ts
+```
+### Get Hooks Script Usage
+The `mod.ts` file is executed as a Deno program and takes one no arguments
+
+#### Example
+```bash
+deno run -q --config=deno.jsonc --allow-read --allow-net https://deno.land/x/deno_slack_hooks/mod.ts
 ```
 ### Get Trigger Script Usage
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ deno run -q --config=deno.jsonc --allow-read --allow-net https://deno.land/x/den
 ```
 
 ### Install Update Script Usage
-The `check_update.ts` file is executed as a Deno program and takes no arguments.
+The `install_update.ts` file is executed as a Deno program and takes no arguments.
 
 #### Example
 ```bash

--- a/README.md
+++ b/README.md
@@ -23,7 +23,35 @@ The hooks currently provided by this repo are `build`, `start`, `check-update`, 
 | `start`           | `slack run`            | Creates a socket connection between the Slack CLI and a Slack workspace for local development that includes hot reloading. For more information, see the [deno-slack-runtime](https://github.com/slackapi/deno-slack-runtime) repository's details on `local-run`. |
 
 
-## Script Overrides
+### Check Update Script Usage
+The `check_update.ts` file is executed as a Deno program and takes no arguments.
+
+#### Example
+```bash
+deno run -q --config=deno.jsonc --allow-read --allow-net https://deno.land/x/deno_slack_hooks/check_update.ts
+```
+### Get Trigger Script Usage
+
+The `get_trigger.ts` file is executed as a Deno program and takes one required argument:
+
+| Arguments  | Description                                           |
+| ---------- | ----------------------------------------------------- |
+| `--source` | Absolute or relative path to your target trigger file. The trigger object must be exported as default from this file. |
+
+
+#### Example
+```bash
+deno run -q --config=deno.jsonc --allow-read --allow-net https://deno.land/x/deno_slack_hooks/get_trigger.ts --source="./trigger.ts"
+```
+
+### Install Update Script Usage
+The `check_update.ts` file is executed as a Deno program and takes no arguments.
+
+#### Example
+```bash
+deno run -q --config=deno.jsonc --allow-run --allow-read --allow-write --allow-net https://deno.land/x/deno_slack_hooks/install_update.ts
+```
+## Script Overrides Usage
 
 If you find yourself needing to override a hook script specified by this library, you can do so in your Slack app's `/slack.json` file! Just specify a new script for the hook in question. All supported hooks can be overwritten.
 


### PR DESCRIPTION
###  Summary
This just adds some script details to the README in case anyone comes looking for more info.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/{project_slug}/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
