### PR TITLE
Return all dependencies during check-update

### DIFF
--- a/src/check_update.ts
+++ b/src/check_update.ts
@@ -278,7 +278,7 @@ export function createUpdateResp(
   // Output information for each dependency
   for (const sdk of Object.values(versionMap)) {
     // Dependency has an update OR the fetch of update failed
-    if (sdk && (sdk.update || sdk.error?.message)) {
+    if (sdk) {
       releases.push(sdk);
 
       // Add the dependency that failed to be fetched to the top-level error message


### PR DESCRIPTION
###  Summary

This PR adjusts the `check-update` logic to return all dependency information, regardless of whether or not there is an update available. This is necessary for the `doctor` command to provide the user information about the dependencies in their project.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/{project_slug}/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
