### PR TITLE
watch all js/ts files

### DIFF
--- a/src/mod.ts
+++ b/src/mod.ts
@@ -21,7 +21,7 @@ export const projectScripts = (args: string[]) => {
     },
     "config": {
       "watch": {
-        "filter-regex": "^manifest\\.(ts|js|json)$",
+        "filter-regex": "\\.(ts|js)$",
         "paths": ["."],
       },
     },


### PR DESCRIPTION
###  Summary

Updates the watch regex to watch any `.js` or `.ts` file changes instead just the manifest file. Not watching `.json` files atm as it would pick up changes in the `.slack` folder that occur on every update/deploy (so it would trigger itself indefinitely).

#### Details
I tried to use a regex w/ a negative look-ahead, `/^(?!\.slack).*\.(ts|js|json)$/`, to filter out the `.slack` folder, but that syntax isn't available in GoLang, which the CLI that interprets this watch config uses.

In the future we'd like to have the CLI automatically filter out changes in the `.slack` folder, which would allow us to watch json files again w/o issue.

### Testing
Update your `slack.json` file to use the hooks from this PR:

```json
{
  "hooks": {
    "get-hooks": "deno run -q --allow-read --allow-net https://raw.githubusercontent.com/slackapi/deno-slack-hooks/3187fc58c01e8c3b1e72ead90fcb59f9569d1eee/src/mod.ts"
  }
}
```

Start local dev w/ `slack run` and change files in the root, or in subdirectories. Any js or ts files should be detected and show something like:

```
File change detected: /Users/brad.harris/dev/slack/deno-reverse-string/functions/reverse_test.ts
reinstalling app...
App successfully reinstalled
```


### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/{project_slug}/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
