### PR TITLE
[HERMES-4040] Support runtime 0.4.0

### DIFF
--- a/src/flags.ts
+++ b/src/flags.ts
@@ -2,14 +2,16 @@ import { parse } from "./deps.ts";
 
 const UNSAFELY_IGNORE_CERT_ERRORS_FLAG =
   "sdk-unsafely-ignore-certificate-errors";
+const SLACK_DEV_DOMAIN_FLAG = "sdk-slack-dev-domain";
 
 export const getStartHookAdditionalDenoFlags = (args: string[]): string => {
   const parsedArgs = parse(args);
-  let certErrorsFlag = "";
-  if (parsedArgs[UNSAFELY_IGNORE_CERT_ERRORS_FLAG]) {
-    certErrorsFlag = `--unsafely-ignore-certificate-errors=${
-      parsedArgs[UNSAFELY_IGNORE_CERT_ERRORS_FLAG]
-    }`;
+  const extraFlagValue = parsedArgs[SLACK_DEV_DOMAIN_FLAG] ??
+    parsedArgs[UNSAFELY_IGNORE_CERT_ERRORS_FLAG] ?? "";
+
+  let extraFlag = "";
+  if (extraFlagValue) {
+    extraFlag = `--sdk-slack-dev-domain=${extraFlagValue}`;
   }
-  return certErrorsFlag;
+  return extraFlag;
 };

--- a/src/libraries.ts
+++ b/src/libraries.ts
@@ -8,6 +8,7 @@ export const DENO_SLACK_RUNTIME = "deno_slack_runtime";
 
 export const VERSIONS = {
   [DENO_SLACK_BUILDER]: "0.1.0",
+  // TODO(mcodik): DO NOT SUBMIT, need to release runtime first and update this version number
   [DENO_SLACK_RUNTIME]: "0.3.1",
   [DENO_SLACK_HOOKS]: hooksVersion,
 };

--- a/src/libraries.ts
+++ b/src/libraries.ts
@@ -8,8 +8,7 @@ export const DENO_SLACK_RUNTIME = "deno_slack_runtime";
 
 export const VERSIONS = {
   [DENO_SLACK_BUILDER]: "0.1.0",
-  // TODO(mcodik): DO NOT SUBMIT, need to release runtime first and update this version number
-  [DENO_SLACK_RUNTIME]: "0.3.1",
+  [DENO_SLACK_RUNTIME]: "0.4.0",
   [DENO_SLACK_HOOKS]: hooksVersion,
 };
 

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -13,7 +13,7 @@ export const projectScripts = (args: string[]) => {
       "build":
         `deno run -q --config=deno.jsonc --allow-read --allow-write --allow-net --allow-run https://deno.land/x/${BUILDER_TAG}/mod.ts`,
       "start":
-        `deno run -q --config=deno.jsonc --allow-read --allow-net ${startHookFlags} https://deno.land/x/${RUNTIME_TAG}/local-run.ts`,
+        `deno run -q --config=deno.jsonc --allow-read --allow-net --allow-run https://deno.land/x/${RUNTIME_TAG}/local-run.ts ${startHookFlags}`,
       "check-update":
         `deno run -q --config=deno.jsonc --allow-read --allow-net https://deno.land/x/${HOOKS_TAG}/check_update.ts`,
       "install-update":

--- a/src/tests/flags_test.ts
+++ b/src/tests/flags_test.ts
@@ -1,31 +1,54 @@
 import { assertEquals } from "../dev_deps.ts";
 import { getStartHookAdditionalDenoFlags } from "../flags.ts";
 
-Deno.test("getStartHookAdditionalFlags sets certificate validation flag, with =", () => {
+Deno.test("getStartHookAdditionalFlags sets sdk-slack-dev-domain, with legacy flag using =", () => {
   const result = getStartHookAdditionalDenoFlags([
     "--sdk-unsafely-ignore-certificate-errors=https://dev1234.slack.com",
   ]);
   assertEquals(
     result,
-    "--unsafely-ignore-certificate-errors=https://dev1234.slack.com",
+    "--sdk-slack-dev-domain=https://dev1234.slack.com",
   );
 });
 
-Deno.test("getStartHookAdditionalFlags sets certificate validation flag", () => {
+Deno.test("getStartHookAdditionalFlags sets sdk-slack-dev-domain, with legacy flag", () => {
   const result = getStartHookAdditionalDenoFlags([
     "--sdk-unsafely-ignore-certificate-errors",
     "https://dev1234.slack.com",
   ]);
   assertEquals(
     result,
-    "--unsafely-ignore-certificate-errors=https://dev1234.slack.com",
+    "--sdk-slack-dev-domain=https://dev1234.slack.com",
+  );
+});
+
+Deno.test("getStartHookAdditionalFlags sets sdk-slack-dev-domain, with sdk-slack-dev-domain flag using =", () => {
+  const result = getStartHookAdditionalDenoFlags([
+    "--sdk-slack-dev-domain=https://dev1234.slack.com",
+  ]);
+  assertEquals(
+    result,
+    "--sdk-slack-dev-domain=https://dev1234.slack.com",
+  );
+});
+
+Deno.test("getStartHookAdditionalFlags sets sdk-slack-dev-domain, with sdk-slack-dev-domain flag", () => {
+  const result = getStartHookAdditionalDenoFlags([
+    "--sdk-slack-dev-domain",
+    "https://dev1234.slack.com",
+  ]);
+  assertEquals(
+    result,
+    "--sdk-slack-dev-domain=https://dev1234.slack.com",
   );
 });
 
 Deno.test("getStartHookAdditionalFlags passes through empty flags", () => {
   const result = getStartHookAdditionalDenoFlags([]);
-  assertEquals(
-    result,
-    "",
-  );
+  assertEquals(result, "");
+});
+
+Deno.test("getStartHookAdditionalFlags passes ignores unsupported flags", () => {
+  const result = getStartHookAdditionalDenoFlags(["--nonsense=foo"]);
+  assertEquals(result, "");
 });


### PR DESCRIPTION
###  Summary

Hooks updates for https://github.com/slackapi/deno-slack-runtime/pull/39 and bumps the runtime version

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/{project_slug}/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
