### PR TITLE
Update check-update to pull from metadata.json

### DIFF
--- a/src/tests/check_update_test.ts
+++ b/src/tests/check_update_test.ts
@@ -246,7 +246,7 @@ Deno.test("check-update hook tests", async (t) => {
           return new Response(mockMetadataJSON);
         });
         const version = await fetchLatestModuleVersion("deno-slack-sdk");
-        assertEquals(version, "1.3.0", "incocrrect version returned");
+        assertEquals(version, "1.3.0", "incorrect version returned");
       },
     );
     mockFetch.uninstall();


### PR DESCRIPTION
###  Summary

This PR updates the `check-update` hook to pull version information directly from the `metadata.json` that's published at https://api.slack.com/slackcli/metadata.json.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/{project_slug}/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
