### PR TITLE
Comparing semver to know if we need to update

### DIFF
--- a/src/check_update.ts
+++ b/src/check_update.ts
@@ -73,7 +73,8 @@ export async function createVersionMap(): Promise<
         error = err;
       }
 
-      const update = (!!current && !!latest) && current !== latest;
+      const update = (!!current && !!latest) &&
+        isNewSemverRelease(current, latest);
       const breaking = hasBreakingChange(current, latest);
 
       versionMap[sdk] = {
@@ -243,6 +244,26 @@ export function extractVersion(str: string): string {
     : str.substring(at + 1, slash);
   return version;
 }
+
+/**
+ * isNewSemverRelease takes two semver formatted strings
+ * and compares them to see if the second argument is a
+ * newer version than the first argument.
+ * If it's newer it returns true, otherwise returns false.
+ */
+
+export const isNewSemverRelease = (current: string, target: string) => {
+  const [currMajor, currMinor, currPatch] = current
+    .split(".")
+    .map((val) => Number(val));
+  const [targetMajor, targetMinor, targetPatch] = target
+    .split(".")
+    .map((val) => Number(val));
+
+  if (targetMajor !== currMajor) return targetMajor > currMajor;
+  if (targetMinor !== currMinor) return targetMinor > currMinor;
+  return targetPatch > currPatch;
+};
 
 /**
  * hasBreakingChange determines whether or not there is a

--- a/src/install_update.ts
+++ b/src/install_update.ts
@@ -33,7 +33,9 @@ export interface Update {
  */
 export const updateDependencies = async () => {
   const { releases } = await checkForSDKUpdates();
-  const updatableReleases = releases.filter((r) => r.current && r.latest);
+  const updatableReleases = releases.filter((r) =>
+    r.update && r.current && r.latest
+  );
   const updateResp = await createUpdateResp(updatableReleases);
 
   // If no errors occurred during installation, re-build

--- a/src/tests/check_update_test.ts
+++ b/src/tests/check_update_test.ts
@@ -8,6 +8,7 @@ import {
   fetchLatestModuleVersion,
   getDenoImportMapFiles,
   hasBreakingChange,
+  isNewSemverRelease,
   readProjectDependencies,
 } from "../check_update.ts";
 
@@ -319,5 +320,46 @@ Deno.test("check-update hook tests", async (t) => {
         assertEquals(true, errorMsg.includes("slack.json"));
       },
     );
+  });
+  await t.step("isNewSemverRelease method", async (evT) => {
+    await evT.step("returns true for semver updates", () => {
+      assertEquals(isNewSemverRelease("0.0.1", "0.0.2"), true);
+      assertEquals(isNewSemverRelease("0.0.1", "0.2.0"), true);
+      assertEquals(isNewSemverRelease("0.0.1", "2.0.0"), true);
+      assertEquals(isNewSemverRelease("0.1.0", "0.1.1"), true);
+      assertEquals(isNewSemverRelease("0.1.0", "0.2.0"), true);
+      assertEquals(isNewSemverRelease("0.1.0", "2.0.0"), true);
+      assertEquals(isNewSemverRelease("1.0.0", "1.0.1"), true);
+      assertEquals(isNewSemverRelease("1.0.0", "1.1.0"), true);
+      assertEquals(isNewSemverRelease("1.0.0", "1.1.1"), true);
+      assertEquals(isNewSemverRelease("1.0.0", "2.0.0"), true);
+      assertEquals(isNewSemverRelease("0.0.2", "0.0.13"), true);
+    });
+    await evT.step("returns false for semver downgrades", () => {
+      assertEquals(isNewSemverRelease("2.0.0", "1.0.0"), false);
+      assertEquals(isNewSemverRelease("2.0.0", "0.1.0"), false);
+      assertEquals(isNewSemverRelease("2.0.0", "0.3.0"), false);
+      assertEquals(isNewSemverRelease("2.0.0", "0.0.1"), false);
+      assertEquals(isNewSemverRelease("2.0.0", "0.0.3"), false);
+      assertEquals(isNewSemverRelease("2.0.0", "1.1.0"), false);
+      assertEquals(isNewSemverRelease("2.0.0", "1.3.0"), false);
+      assertEquals(isNewSemverRelease("2.0.0", "1.1.1"), false);
+      assertEquals(isNewSemverRelease("2.0.0", "1.3.3"), false);
+      assertEquals(isNewSemverRelease("0.2.0", "0.1.0"), false);
+      assertEquals(isNewSemverRelease("0.2.0", "0.0.1"), false);
+      assertEquals(isNewSemverRelease("0.2.0", "0.0.3"), false);
+      assertEquals(isNewSemverRelease("0.2.0", "0.1.1"), false);
+      assertEquals(isNewSemverRelease("0.2.0", "0.1.3"), false);
+      assertEquals(isNewSemverRelease("0.0.2", "0.0.1"), false);
+      assertEquals(isNewSemverRelease("0.0.20", "0.0.13"), false);
+    });
+    await evT.step("returns false for semver matches", () => {
+      assertEquals(isNewSemverRelease("0.0.1", "0.0.1"), false);
+      assertEquals(isNewSemverRelease("0.1.0", "0.1.0"), false);
+      assertEquals(isNewSemverRelease("0.1.1", "0.1.1"), false);
+      assertEquals(isNewSemverRelease("1.0.0", "1.0.0"), false);
+      assertEquals(isNewSemverRelease("1.0.1", "1.0.1"), false);
+      assertEquals(isNewSemverRelease("1.1.1", "1.1.1"), false);
+    });
   });
 });


### PR DESCRIPTION
###  Summary
We shouldn't prompt the user to upgrade if they're on a newer version. This is being put in place now that we're going to have a suggested version rather than when we always just used latest.

### Testing
Change your versions manually and then run the hook locally

```bash
deno run -q --config=deno.jsonc --allow-run --allow-read --allow-write --allow-net <your-local-path>/deno-slack-hooks/src/install_update.ts
```

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/{project_slug}/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
