### PR TITLE
Allow environment variables in hooks related to running locally or deploying to ROSI

### DIFF
--- a/src/mod.ts
+++ b/src/mod.ts
@@ -7,13 +7,13 @@ export const projectScripts = (args: string[]) => {
     "runtime": "deno",
     "hooks": {
       "get-manifest":
-        `deno run -q --config=deno.jsonc --allow-read --allow-net https://deno.land/x/${BUILDER_TAG}/mod.ts --manifest`,
+        `deno run -q --config=deno.jsonc --allow-read --allow-net --allow-env https://deno.land/x/${BUILDER_TAG}/mod.ts --manifest`,
       "get-trigger":
         `deno run -q --config=deno.jsonc --allow-read --allow-net https://deno.land/x/${HOOKS_TAG}/get_trigger.ts`,
       "build":
-        `deno run -q --config=deno.jsonc --allow-read --allow-write --allow-net --allow-run https://deno.land/x/${BUILDER_TAG}/mod.ts`,
+        `deno run -q --config=deno.jsonc --allow-read --allow-write --allow-net --allow-run --allow-env https://deno.land/x/${BUILDER_TAG}/mod.ts`,
       "start":
-        `deno run -q --config=deno.jsonc --allow-read --allow-net --allow-run https://deno.land/x/${RUNTIME_TAG}/local-run.ts ${startHookFlags}`,
+        `deno run -q --config=deno.jsonc --allow-read --allow-net --allow-run --allow-env https://deno.land/x/${RUNTIME_TAG}/local-run.ts ${startHookFlags}`,
       "check-update":
         `deno run -q --config=deno.jsonc --allow-read --allow-net https://deno.land/x/${HOOKS_TAG}/check_update.ts`,
       "install-update":


### PR DESCRIPTION
###  Summary

Implement App manifest override proposal with environment variables

- Proposal: https://corp.quip.com/O1t1AuDG3HLk/App-Manifest-Overrides
- JIRA: https://jira.tinyspeck.com/browse/HERMES-4137

Related CLI PR:
- https://github.com/slackapi/slack-cli/pull/776

Related runtime PR: 
- https://github.com/slackapi/deno-slack-runtime/pull/40

#### Requirements (place an `x` in each `[ ]`)
* [x] I've read and understood the [Contributing Guidelines](https://github.com/{project_slug}/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
