### PR TITLE
Update Deno Slack Runtime to 0.5.1

### DIFF
--- a/src/libraries.ts
+++ b/src/libraries.ts
@@ -8,7 +8,7 @@ export const DENO_SLACK_RUNTIME = "deno_slack_runtime";
 
 export const VERSIONS = {
   [DENO_SLACK_BUILDER]: "0.2.0",
-  [DENO_SLACK_RUNTIME]: "0.5.0",
+  [DENO_SLACK_RUNTIME]: "0.5.1",
   [DENO_SLACK_HOOKS]: hooksVersion,
 };
 


### PR DESCRIPTION
###  Summary

This pull request updates the Deno Slack Runtime to 0.5.1 ([release notes](https://github.com/slackapi/deno-slack-runtime/releases/tag/0.5.1)).

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/{project_slug}/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
