### PR TITLE
Allow env for get trigger hook

### DIFF
--- a/src/mod.ts
+++ b/src/mod.ts
@@ -9,7 +9,7 @@ export const projectScripts = (args: string[]) => {
       "get-manifest":
         `deno run -q --config=deno.jsonc --allow-read --allow-net --allow-env https://deno.land/x/${BUILDER_TAG}/mod.ts --manifest`,
       "get-trigger":
-        `deno run -q --config=deno.jsonc --allow-read --allow-net https://deno.land/x/${HOOKS_TAG}/get_trigger.ts`,
+        `deno run -q --config=deno.jsonc --allow-read --allow-net --allow-env https://deno.land/x/${HOOKS_TAG}/get_trigger.ts`,
       "build":
         `deno run -q --config=deno.jsonc --allow-read --allow-write --allow-net --allow-run --allow-env https://deno.land/x/${BUILDER_TAG}/mod.ts`,
       "start":


### PR DESCRIPTION
###  Summary

This was a user request asking enable Environment variables in trigger files, this PR adds this functionality. 

JIRA: HERMES-4830

testing steps:

1. add the following to your `slack.json` file in a test application
  ```json
   "get-trigger":
          "deno run -q --config=deno.jsonc --allow-read --allow-net --allow-env https://deno.land/x/deno_slack_hooks/get_trigger.ts"
  ```
2. Add something in a trigger file that uses environment variables ex: `Deno.env.get("NAME")`
3. execute a trigger update ex: `hermes trigger update --trigger-def triggers/<path to my trigger>.ts --trigger-id <my trigger ID>`
4. Everything should be successful

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/{project_slug}/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
