### PR TITLE
Ignore API-type functions when bundling function code in the `build` hook

### DIFF
--- a/src/build.ts
+++ b/src/build.ts
@@ -27,9 +27,14 @@ export const validateAndCreateFunctions = async (
 
   // Write out functions to disk
   for (const fnId in manifest.functions) {
+    const fnDef = manifest.functions[fnId];
+    // For API type functions, there are no function files.
+    if (fnDef.type === "API") {
+      continue;
+    }
     const fnFilePath = path.join(
       workingDirectory,
-      manifest.functions[fnId].source_file,
+      fnDef.source_file,
     );
     await createFunctionFile(
       outputDirectory,

--- a/src/tests/build_test.ts
+++ b/src/tests/build_test.ts
@@ -48,6 +48,21 @@ Deno.test("build hook tests", async (t) => {
                 "properties": {},
               },
             },
+            "api_function_that_should_not_be_built": {
+              "type": "API",
+              "title": "API function",
+              "description": "should most definitely not be bundled",
+              "source_file":
+                "src/tests/fixtures/functions/this_shouldnt_matter.ts",
+              "input_parameters": {
+                "required": [],
+                "properties": {},
+              },
+              "output_parameters": {
+                "required": [],
+                "properties": {},
+              },
+            },
           },
         };
         const outputDir = await Deno.makeTempDir();


### PR DESCRIPTION
###  Summary

We already ignore API-type functions when validating manifest, but failed to do so in the build hook when I merged the -builder repo in here.