### PR TITLE
Format docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,35 +1,44 @@
 # deno-slack-hooks
 
-This library is intended to be used in applications running on Slack's next-generation application platform, focused on remixable
-units of functionality encapsulated as ephemeral functions. It implements the communication contract between the
-[Slack CLI][cli] and any Slack app development SDKs.
+This library is intended to be used in applications running on Slack's
+next-generation application platform, focused on remixable units of
+functionality encapsulated as ephemeral functions. It implements the
+communication contract between the [Slack CLI][cli] and any Slack app
+development SDKs.
 
 ## Overview
 
-This library enables inter-process communication between the [Slack CLI tool][cli] and apps authored for Slack's
-[next-generation platform][nextgen]. The CLI delegates various tasks to the application SDK by means of invoking
-a process and expecting specific kinds of responses in the process' resultant stdout. For a full list of these
-tasks, check out the [Supported Scripts](#supported-scripts) section.
+This library enables inter-process communication between the
+[Slack CLI tool][cli] and apps authored for Slack's
+[next-generation platform][nextgen]. The CLI delegates various tasks to the
+application SDK by means of invoking a process and expecting specific kinds of
+responses in the process' resultant stdout. For a full list of these tasks,
+check out the [Supported Scripts](#supported-scripts) section.
 
 ## Requirements
 
-This library requires a recent (at least 1.22) version of [deno](https://deno.land).
+This library requires a recent (at least 1.22) version of
+[deno](https://deno.land).
 
-Any invocations of this library require additional [deno permissions](https://deno.land/manual/getting_started/permissions), depending on which of the [Supported Scripts](#supported-scripts) is being invoked.
+Any invocations of this library require additional
+[deno permissions](https://deno.land/manual/getting_started/permissions),
+depending on which of the [Supported Scripts](#supported-scripts) is being
+invoked.
 
 ## Supported Scripts
 
-The hooks currently provided by this repo are `build`, `start`, `check-update`, `install-update`, `get-trigger`, and `get-manifest`.
+The hooks currently provided by this repo are `build`, `start`, `check-update`,
+`install-update`, `get-trigger`, and `get-manifest`.
 
-| Hook Name         | CLI Command            | Description                     |
-| ----------------- | ---------------------- | ------------------------------- |
-| `build`           | `slack deploy`         | Bundles any functions with Deno into an output directory that's compatible with the Run on Slack runtime. Implemented in `build.ts`. |
-| `check-update`    | `slack upgrade`        | Checks the App's SDK dependencies to determine whether or not any of your libraries need to be updated. Implemented in `check_update.ts`. |
-| `get-manifest`    | `slack manifest`       | Converts a `manifest.json`, `manifest.js`, or `manifest.ts` file into a valid manifest JSON payload. Implemented in `get_manifest.ts`. |
-| `get-hooks`       | All                    | Fetches the list of available hooks for the CLI from this repository. Implemented in `mod.ts`. |
-| `get-trigger`     | `slack trigger create` | Converts a specified `json`, `js`, or `ts` file into a valid trigger JSON payload to be uploaded by the CLI to the `workflows.triggers.create` Slack API endpoint. Implemented in `get_trigger.ts`. |
-| `install-update`  | `slack upgrade`        | Prompts the user to automatically update any dependencies that need to be updated based on the result of the `check-update` hook. Implemented in `install_update.ts`. |
-| `start`           | `slack run`            | While developing and locally running a deno-slack-based application, the CLI manages a socket connection with Slack's backend and delegates to this hook for invoking the correct application function for relevant events incoming via this connection. For more information, see the [deno-slack-runtime](https://github.com/slackapi/deno-slack-runtime) repository's details on `local-run`. |
+| Hook Name        | CLI Command            | Description                                                                                                                                                                                                                                                                                                                                                                                      |
+| ---------------- | ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `build`          | `slack deploy`         | Bundles any functions with Deno into an output directory that's compatible with the Run on Slack runtime. Implemented in `build.ts`.                                                                                                                                                                                                                                                             |
+| `check-update`   | `slack upgrade`        | Checks the App's SDK dependencies to determine whether or not any of your libraries need to be updated. Implemented in `check_update.ts`.                                                                                                                                                                                                                                                        |
+| `get-manifest`   | `slack manifest`       | Converts a `manifest.json`, `manifest.js`, or `manifest.ts` file into a valid manifest JSON payload. Implemented in `get_manifest.ts`.                                                                                                                                                                                                                                                           |
+| `get-hooks`      | All                    | Fetches the list of available hooks for the CLI from this repository. Implemented in `mod.ts`.                                                                                                                                                                                                                                                                                                   |
+| `get-trigger`    | `slack trigger create` | Converts a specified `json`, `js`, or `ts` file into a valid trigger JSON payload to be uploaded by the CLI to the `workflows.triggers.create` Slack API endpoint. Implemented in `get_trigger.ts`.                                                                                                                                                                                              |
+| `install-update` | `slack upgrade`        | Prompts the user to automatically update any dependencies that need to be updated based on the result of the `check-update` hook. Implemented in `install_update.ts`.                                                                                                                                                                                                                            |
+| `start`          | `slack run`            | While developing and locally running a deno-slack-based application, the CLI manages a socket connection with Slack's backend and delegates to this hook for invoking the correct application function for relevant events incoming via this connection. For more information, see the [deno-slack-runtime](https://github.com/slackapi/deno-slack-runtime) repository's details on `local-run`. |
 
 ### Check Update Script Usage
 
@@ -53,10 +62,11 @@ deno run -q --config=deno.jsonc --allow-read --allow-net https://deno.land/x/den
 
 ### Get Trigger Script Usage
 
-The `get_trigger.ts` file is executed as a Deno program and takes one required argument:
+The `get_trigger.ts` file is executed as a Deno program and takes one required
+argument:
 
-| Arguments  | Description                                           |
-| ---------- | ----------------------------------------------------- |
+| Arguments  | Description                                                                                                           |
+| ---------- | --------------------------------------------------------------------------------------------------------------------- |
 | `--source` | Absolute or relative path to your target trigger file. The trigger object must be exported as default from this file. |
 
 #### Example
@@ -67,7 +77,8 @@ deno run -q --config=deno.jsonc --allow-read --allow-net https://deno.land/x/den
 
 ### Install Update Script Usage
 
-The `install_update.ts` file is executed as a Deno program and takes no arguments.
+The `install_update.ts` file is executed as a Deno program and takes no
+arguments.
 
 #### Example
 
@@ -77,9 +88,14 @@ deno run -q --config=deno.jsonc --allow-run --allow-read --allow-write --allow-n
 
 ## Script Overrides Usage
 
-If you find yourself needing to override a hook script specified by this library, you can do so in your Slack app's `/slack.json` file! Just specify a new script for the hook in question. All supported hooks can be overwritten.
+If you find yourself needing to override a hook script specified by this
+library, you can do so in your Slack app's `/slack.json` file! Just specify a
+new script for the hook in question. All supported hooks can be overwritten.
 
-Below is an example `/slack.json` file that overrides the `build` script to point to your local repo for development purposes. It's using an implicit "latest" version of the <https://deno.land/x/deno_slack_hooks/mod.ts> script, but we suggest pinning it to whatever the latest version is.
+Below is an example `/slack.json` file that overrides the `build` script to
+point to your local repo for development purposes. It's using an implicit
+"latest" version of the <https://deno.land/x/deno_slack_hooks/mod.ts> script,
+but we suggest pinning it to whatever the latest version is.
 
 ```json
 {
@@ -90,9 +106,12 @@ Below is an example `/slack.json` file that overrides the `build` script to poin
 }
 ```
 
-The [Slack CLI][cli] will automatically know to pick up your local hook definition and use that instead of what's defined by this library.
+The [Slack CLI][cli] will automatically know to pick up your local hook
+definition and use that instead of what's defined by this library.
 
-This can also be used to change the flags sent to the `deno run` command if you decide to change the location of your config file, or switch to an import map instead.
+This can also be used to change the flags sent to the `deno run` command if you
+decide to change the location of your config file, or switch to an import map
+instead.
 
 ---
 

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -2,7 +2,7 @@
   "$schema": "https://deno.land/x/deno/cli/schemas/config-file.v1.json",
   "fmt": {
     "files": {
-      "include": ["src"],
+      "include": ["src", "docs", "README.md"],
       "exclude": ["src/tests/fixtures"]
     },
     "options": {


### PR DESCRIPTION
###  Summary

This PR adds `docs` directory and the `README` to the `fmt.files.include` portion of the `deno.jsonc` and runs the formatter.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/{project_slug}/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
