### PR TITLE
Replace calls to Deno.run with Deno.Command

### DIFF
--- a/src/build.ts
+++ b/src/build.ts
@@ -66,9 +66,8 @@ const createFunctionFile = async (
 
   try {
     // call out to deno to handle bundling
-    const p = Deno.run({
-      cmd: [
-        denoExecutablePath,
+    const commander = new Deno.Command(denoExecutablePath, {
+      args: [
         "bundle",
         "--quiet",
         fnFilePath,
@@ -76,8 +75,10 @@ const createFunctionFile = async (
       ],
     });
 
-    const status = await p.status();
-    p.close();
+    const subprocess = commander.spawn();
+    const status = await subprocess.status;
+    subprocess.kill();
+
     if (status.code !== 0 || !status.success) {
       throw new Error(`Error bundling function file: ${fnId}`);
     }

--- a/src/install_update.ts
+++ b/src/install_update.ts
@@ -175,11 +175,14 @@ export function updateDependencyMap(
  * `install-update`, this is in order to cache the dependency version
  * updates that occurred.
  */
-function runBuildHook(): void {
+async function runBuildHook(): Promise<void> {
   try {
     const { hooks: { build } } = projectScripts([]);
-    const buildArgs = build.split(" ");
-    Deno.run({ cmd: buildArgs });
+    const [denoExecutablePath, ...buildArgs] = build.split(" ");
+    const commander = new Deno.Command(denoExecutablePath, { args: buildArgs });
+    const subprocess = commander.spawn();
+    await subprocess.status;
+    subprocess.kill();
   } catch (err) {
     throw new Error(err);
   }

--- a/src/install_update.ts
+++ b/src/install_update.ts
@@ -45,7 +45,7 @@ export const updateDependencies = async () => {
       // TODO :: This try/catch should be nested within createUpdateResp
       // but doing so surfaces an issue with the --allow-run flag not
       // being used, despite its presence and success at this level
-      runBuildHook();
+      await runBuildHook();
     } catch (err) {
       updateResp.error = { message: err.message };
     }

--- a/src/tests/build_test.ts
+++ b/src/tests/build_test.ts
@@ -66,15 +66,19 @@ Deno.test("build hook tests", async (t) => {
           },
         };
         const outputDir = await Deno.makeTempDir();
-        // Stub out call to `Deno.run` and fake return a success
-        const runResponse = {
-          close: () => {},
-          status: () => Promise.resolve({ code: 0, success: true }),
-        } as unknown as Deno.Process<Deno.RunOptions>;
-        const runStub = stub(
+        // Stub out call to `Deno.Command` and fake return a success
+        const commandResponse = {
+          spawn: () => {
+            return {
+              kill: () => {},
+              status: Promise.resolve({ code: 0, success: true }),
+            };
+          },
+        } as Deno.Command;
+        const commandStub = stub(
           Deno,
-          "run",
-          returnsNext([runResponse, runResponse]),
+          "Command",
+          returnsNext([commandResponse, commandResponse]),
         );
         await validateAndCreateFunctions(
           Deno.cwd(),
@@ -82,8 +86,8 @@ Deno.test("build hook tests", async (t) => {
           manifest,
           protocol,
         );
-        assertSpyCalls(runStub, 2);
-        runStub.restore();
+        assertSpyCalls(commandStub, 2);
+        commandStub.restore();
       },
     );
 
@@ -261,19 +265,23 @@ Deno.test("build hook tests", async (t) => {
         manifest,
         protocol,
       );
-      // Stub out call to `Deno.run` and fake return a success
-      const runResponse = {
-        close: () => {},
-        status: () => Promise.resolve({ code: 0, success: true }),
-      } as unknown as Deno.Process<Deno.RunOptions>;
-      const runStub = stub(
+      // Stub out call to `Deno.Command` and fake return a success
+      const commandResponse = {
+        spawn: () => {
+          return {
+            kill: () => {},
+            status: Promise.resolve({ code: 0, success: true }),
+          };
+        },
+      } as Deno.Command;
+      const commandStub = stub(
         Deno,
-        "run",
-        returnsNext([runResponse, runResponse]),
+        "Command",
+        returnsNext([commandResponse, commandResponse]),
       );
-      // Make sure we didn't shell out to Deno.run
-      assertSpyCalls(runStub, 0);
-      runStub.restore();
+      // Make sure we didn't shell out to Deno.Command
+      assertSpyCalls(commandStub, 0);
+      commandStub.restore();
     });
   });
 });


### PR DESCRIPTION
###  Summary

With [1.33](https://github.com/denoland/deno/releases/tag/v1.33.0) came the deprecation of `Deno.run`, so we need to switch to using [`Deno.Command`](https://deno.land/api@v1.33.1?unstable=&s=Deno.Command). This was stabilized as part of the [1.31 release](https://deno.com/blog/v1.31#changes-to-deno-apis), so we might want to wait a bit to allow folks time to upgrade their local version of Deno.

I was only able to get this to work through the `spawn` method to create a child process, I was not able to get `output` or `outputSync` methods to work.

### Testing

Wasn't able to test this yet, just applied the code changes. We'll need to validate both the `build` and `install-update` hooks

Check out this repo and update both of the above hooks to point to your local repo
```json
  "build": "...",
  "install-update": "...",
```

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/{project_slug}/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).