### PR TITLE
update the plateform to support more imports

### DIFF
--- a/src/bundler/esbuild_bundler.ts
+++ b/src/bundler/esbuild_bundler.ts
@@ -15,7 +15,7 @@ export const EsbuildBundler = {
       // esbuild configuration options https://esbuild.github.io/api/#overview
       const result = await esbuild.build({
         entryPoints: [options.entrypoint],
-        platform: "neutral",
+        platform: "browser",
         target: "deno1", // TODO: the versions should come from the user defined input
         format: "esm", // esm format stands for "ECMAScript module"
         bundle: true, // inline any imported dependencies into the file itself


### PR DESCRIPTION
###  Summary

This PR introduces a patch that allows ebuild to bundle a wider range of npm specifiers note that this is not a full proof solution and that packages such as [axios](https://www.npmjs.com/package/axios) will bundle correctly but create runtime errors

#### Testing

1. create an app that uses an npm specifier example `dayjs` 
```ts
import dayjs from "npm:dayjs@1.11.10";

const test = dayjs("2018-08-08");
console.log(test.year());
```
2. run `slack deploy`
3. The app should bundle and run as expected

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/{project_slug}/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
