### PR TITLE
Split out health score as separate job that runs after test

### DIFF
--- a/.github/workflows/deno-ci.yml
+++ b/.github/workflows/deno-ci.yml
@@ -17,28 +17,31 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-
     steps:
       - name: Setup repo
         uses: actions/checkout@v4
-
       - name: Setup Deno
         uses: denoland/setup-deno@v1
         with:
           deno-version: v1.x
-
       - name: Run tests
         run: deno task test
-
       - name: Generate CodeCov-friendly coverage report
         run: deno task generate-lcov
-
       - name: Upload coverage to CodeCov
         uses: codecov/codecov-action@v4
         with:
           file: ./lcov.info
           token: ${{ secrets.CODECOV_TOKEN }}
-                        
+
+  health-score:
+    needs: test
+    permissions:
+      checks: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup repo
+        uses: actions/checkout@v4
       - name: Report health score
         uses: slackapi/slack-health-score@v0
         with:


### PR DESCRIPTION
also explicitly has check-writing permissions.
