### PR TITLE
chore: update the esbuild dependencies

### DIFF
--- a/src/bundler/esbuild_bundler.ts
+++ b/src/bundler/esbuild_bundler.ts
@@ -1,5 +1,5 @@
-import * as esbuild from "npm:esbuild@0.23.1";
-import { denoPlugins } from "jsr:@luca/esbuild-deno-loader@0.10.3";
+import * as esbuild from "npm:esbuild@0.24.2";
+import { denoPlugins } from "jsr:@luca/esbuild-deno-loader@0.11.1";
 
 type EsbuildBundleOptions = {
   /** The path to the file being bundled */


### PR DESCRIPTION
### Summary

This PR aims to improve the bundle experience of the SDK by updating the esbuild-deno-loader version

You can tests this out by overriding the "build" in the `slack.json` file of a peoject

```json
{
  "hooks": {
    "get-hooks": "deno run -q --allow-read --allow-net https://deno.land/x/deno_slack_hooks@1.3.1/mod.ts",
    "build": "deno run -q --config=deno.jsonc --allow-read --allow-write --allow-net --allow-run --allow-env --allow-sys=osRelease https://raw.githubusercontent.com/slackapi/deno-slack-hooks/refs/heads/update-dependencies/src/build.ts"
  }
}

```

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/{project_slug}/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
