### PR TITLE
fix: check updates for known deps imported in deno configs & .slack/hooks

### DIFF
--- a/src/check_update.ts
+++ b/src/check_update.ts
@@ -144,6 +144,8 @@ export async function gatherDependencyFiles(
   }
 > {
   const dependencyFiles: [string, "imports" | "hooks"][] = [
+    ["deno.json", "imports"],
+    ["deno.jsonc", "imports"],
     ["slack.json", "hooks"],
     ["slack.jsonc", "hooks"],
   ];
@@ -162,6 +164,8 @@ export async function gatherDependencyFiles(
  * of filename and dependency key pairs.
  *
  * ex: [["import_map.json", "imports"], ["custom_map.json", "imports"]]
+ *
+ * Removed in Deno 2 for deno.json but kept for backward compatibility.
  */
 export async function getDenoImportMapFiles(
   cwd: string,

--- a/src/check_update.ts
+++ b/src/check_update.ts
@@ -1,4 +1,5 @@
 import type { JsonValue } from "jsr:@std/jsonc@^1.0.1";
+import { join } from "jsr:@std/path@1.1.0";
 import { getProtocolInterface } from "https://deno.land/x/deno_slack_protocols@0.0.2/mod.ts";
 
 import {
@@ -107,7 +108,7 @@ export async function readProjectDependencies(): Promise<
 
   for (const [fileName, depKey] of dependencyFiles) {
     try {
-      const fileJSON = await getJSON(`${cwd}/${fileName}`);
+      const fileJSON = await getJSON(join(cwd, fileName));
       const fileDependencies = extractDependencies(fileJSON, depKey);
 
       // For each dependency found, compare to SDK-related dependency
@@ -148,6 +149,7 @@ export async function gatherDependencyFiles(
     ["deno.jsonc", "imports"],
     ["slack.json", "hooks"],
     ["slack.jsonc", "hooks"],
+    [join(".slack", "hooks.json"), "hooks"],
   ];
 
   // Parse deno.* files for `importMap` dependency file
@@ -165,7 +167,7 @@ export async function gatherDependencyFiles(
  *
  * ex: [["import_map.json", "imports"], ["custom_map.json", "imports"]]
  *
- * Removed in Deno 2 for deno.json but kept for backward compatibility.
+ * With Deno 2 we favor imports in deno.json but kept this for backward compatibility.
  */
 export async function getDenoImportMapFiles(
   cwd: string,
@@ -181,7 +183,7 @@ export async function getDenoImportMapFiles(
 
   for (const fileName of denoJSONFiles) {
     try {
-      const denoJSON = await getJSON(`${cwd}/${fileName}`);
+      const denoJSON = await getJSON(join(cwd, fileName));
       const jsonIsParsable = denoJSON && typeof denoJSON === "object" &&
         !Array.isArray(denoJSON) && denoJSON.importMap;
 

--- a/src/install_update.ts
+++ b/src/install_update.ts
@@ -1,5 +1,6 @@
 import { getProtocolInterface } from "https://deno.land/x/deno_slack_protocols@0.0.2/mod.ts";
 import type { JsonValue } from "jsr:@std/jsonc@^1.0.1";
+import { join } from "jsr:@std/path@1.1.0";
 
 import {
   checkForSDKUpdates,
@@ -76,7 +77,7 @@ export async function createUpdateResp(
       // Update dependency file with latest dependency versions
       try {
         const fileUpdateResp = await updateDependencyFile(
-          `${cwd}/${file}`,
+          join(cwd, file),
           releases,
         );
         updateResp.updates = [...updateResp.updates, ...fileUpdateResp];

--- a/src/tests/check_update_test.ts
+++ b/src/tests/check_update_test.ts
@@ -21,12 +21,14 @@ const MOCK_SLACK_JSON = JSON.stringify({
 const MOCK_IMPORT_MAP_JSON = JSON.stringify({
   imports: {
     "deno-slack-sdk/": "https://deno.land/x/deno_slack_sdk@0.0.6/",
-    "deno-slack-api/": "https://deno.land/x/deno_slack_api@0.0.6/",
   },
 });
 
 const MOCK_DENO_JSON = JSON.stringify({
   "importMap": "import_map.json",
+  "imports": {
+    "deno-slack-api/": "https://deno.land/x/deno_slack_api@0.0.6/",
+  },
 });
 
 const MOCK_SLACK_JSON_FILE = new TextEncoder().encode(MOCK_SLACK_JSON);
@@ -110,6 +112,11 @@ Deno.test("check-update hook tests", async (t) => {
     await evT.step(
       "given import_map.json or slack.json file contents, an array of key, value dependency pairs is returned",
       () => {
+        const denoJSONActual = extractDependencies(
+          JSON.parse(MOCK_DENO_JSON),
+          "imports",
+        );
+
         const importMapActual = extractDependencies(
           JSON.parse(MOCK_IMPORT_MAP_JSON),
           "imports",
@@ -120,10 +127,15 @@ Deno.test("check-update hook tests", async (t) => {
           "hooks",
         );
 
+        const denoJSONExpected: [string, string][] = [[
+          "deno-slack-api/",
+          "https://deno.land/x/deno_slack_api@0.0.6/",
+        ]];
+
         const importMapExpected: [string, string][] = [[
           "deno-slack-sdk/",
           "https://deno.land/x/deno_slack_sdk@0.0.6/",
-        ], ["deno-slack-api/", "https://deno.land/x/deno_slack_api@0.0.6/"]];
+        ]];
 
         const slackHooksExpected: [string, string][] = [
           [
@@ -133,9 +145,17 @@ Deno.test("check-update hook tests", async (t) => {
         ];
 
         assertEquals(
+          denoJSONActual,
+          denoJSONExpected,
+          `Expected: ${JSON.stringify(denoJSONExpected)}\n Actual: ${
+            JSON.stringify(denoJSONActual)
+          }`,
+        );
+
+        assertEquals(
           importMapActual,
           importMapExpected,
-          `Expected: ${JSON.stringify([])}\n Actual: ${
+          `Expected: ${JSON.stringify(importMapExpected)}\n Actual: ${
             JSON.stringify(importMapActual)
           }`,
         );
@@ -143,8 +163,8 @@ Deno.test("check-update hook tests", async (t) => {
         assertEquals(
           slackHooksActual,
           slackHooksExpected,
-          `Expected: ${JSON.stringify([])}\n Actual: ${
-            JSON.stringify(importMapActual)
+          `Expected: ${JSON.stringify(slackHooksExpected)}\n Actual: ${
+            JSON.stringify(slackHooksActual)
           }`,
         );
       },


### PR DESCRIPTION
### Summary

This PR adds `deno.json` and `deno.jsonc` to the list of files containing `imports` with dependencies to update for support of recent sample changes 🤖 ✨ 

### Reviewers

Confirm the `doctor` command finds these dependencies:

```sh
$ slack create asdf -t slack-samples/deno-starter-template
$ cd asdf
$ vim .slack/hooks.json
{
  "hooks": {
    "get-hooks": "deno run -q --allow-read --allow-net https://deno.land/x/deno_slack_hooks@1.3.2/mod.ts",
    "check-update": "deno run -q --allow-read --allow-net /path/to/deno-slack-hooks/src/check_update.ts",
    "install-update": "deno run -q --config=deno.jsonc --allow-run --allow-read --allow-write --allow-net /path/to/deno-slack-hooks/src/install_update.ts"
  }
}
$ slack doctor
$ vim deno.jsonc
{
  "...": {},
  "imports": {
    "@std/assert": "jsr:@std/assert@^1.0.13",
    "@std/testing": "jsr:@std/testing@^1.0.12",
    "deno-slack-sdk/": "https://deno.land/x/deno_slack_sdk@2.0.0/",
    "deno-slack-api/": "https://deno.land/x/deno_slack_api@2.0.0/"
  }
}
$ slack update
```

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/{project_slug}/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
