### PR TITLE
fix: redirect changelog links to the current docs site

### DIFF
--- a/src/check_update.ts
+++ b/src/check_update.ts
@@ -272,7 +272,7 @@ export function createUpdateResp(
   const name = "the Slack SDK";
   const releases = [];
   const message = "";
-  const url = "https://api.slack.com/automation/changelog";
+  const url = "https://docs.slack.dev/changelog";
   const fileErrorMsg = createFileErrorMsg(inaccessibleFiles);
 
   let error = null;


### PR DESCRIPTION
### Summary

This PR replaces the link output when changes to SDK versions are reflected in the upstream `metadata.json` 🙏 ✨ 

### Reviewers

Observe the link to the changelog shows an expected path when attempting an update:

```sh
$ slack update -v
...
starting hook command: deno run -q --allow-read --allow-net /Users/eden.zimbelman/programming/tools/deno-slack-hooks/src/check_update.ts --protocol=message-boundaries --boundary=7978354458794d357170d41d8cd98f00b204e9800998ecf8427e
7978354458794d357170d41d8cd98f00b204e9800998ecf8427e{"name":"the Slack SDK","message":"","releases":[],"url":"https://docs.slack.dev/changelog","error":null}7978354458794d357170d41d8cd98f00b204e9800998ecf8427e
finished hook command: deno run -q --allow-read --allow-net /Users/eden.zimbelman/programming/tools/deno-slack-hooks/src/check_update.ts --protocol=message-boundaries --boundary=7978354458794d357170d41d8cd98f00b204e9800998ecf8427e
```

### Notes

- Changes of #103 should bring found dependencies to these releases 🤖

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/{project_slug}/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
