### PR TITLE
feat: add support for updates to `.slack/hooks.json` & imports in `deno.json`

### DIFF
--- a/src/install_update.ts
+++ b/src/install_update.ts
@@ -1,5 +1,6 @@
 import { getProtocolInterface } from "https://deno.land/x/deno_slack_protocols@0.0.2/mod.ts";
 import type { JsonValue } from "jsr:@std/jsonc@^1.0.1";
+import { join } from "jsr:@std/path@1.1.0";
 
 import {
   checkForSDKUpdates,
@@ -76,7 +77,7 @@ export async function createUpdateResp(
       // Update dependency file with latest dependency versions
       try {
         const fileUpdateResp = await updateDependencyFile(
-          `${cwd}/${file}`,
+          join(cwd, file),
           releases,
         );
         updateResp.updates = [...updateResp.updates, ...fileUpdateResp];

--- a/src/tests/check_update_test.ts
+++ b/src/tests/check_update_test.ts
@@ -6,19 +6,19 @@ import {
   extractDependencies,
   extractVersion,
   fetchLatestModuleVersion,
-  getDenoImportMapFiles,
+  getDenoImportFiles,
   hasBreakingChange,
   readProjectDependencies,
 } from "../check_update.ts";
 
-const MOCK_SLACK_JSON = JSON.stringify({
+const MOCK_HOOKS_JSON = JSON.stringify({
   hooks: {
     "get-hooks":
       "deno run -q --allow-read --allow-net https://deno.land/x/deno_slack_hooks@0.0.9/mod.ts",
   },
 });
 
-const MOCK_IMPORT_MAP_JSON = JSON.stringify({
+const MOCK_IMPORTS_JSON = JSON.stringify({
   imports: {
     "deno-slack-sdk/": "https://deno.land/x/deno_slack_sdk@0.0.6/",
     "deno-slack-api/": "https://deno.land/x/deno_slack_api@0.0.6/",
@@ -29,16 +29,33 @@ const MOCK_DENO_JSON = JSON.stringify({
   "importMap": "import_map.json",
 });
 
-const MOCK_SLACK_JSON_FILE = new TextEncoder().encode(MOCK_SLACK_JSON);
-const MOCK_IMPORT_MAP_FILE = new TextEncoder().encode(MOCK_IMPORT_MAP_JSON);
+const MOCK_SLACK_JSON_FILE = new TextEncoder().encode(MOCK_HOOKS_JSON);
+const MOCK_DOT_SLACK_HOOKS_JSON_FILE = new TextEncoder().encode(
+  MOCK_HOOKS_JSON,
+);
+const MOCK_IMPORT_MAP_FILE = new TextEncoder().encode(MOCK_IMPORTS_JSON);
 const MOCK_DENO_JSON_FILE = new TextEncoder().encode(MOCK_DENO_JSON);
+const MOCK_IMPORTS_IN_DENO_JSON_FILE = new TextEncoder().encode(
+  MOCK_IMPORTS_JSON,
+);
+const EMPTY_JSON_FILE = new TextEncoder().encode("{}");
+
+const setEmptyJsonFiles = () => {
+  mockFile.prepareVirtualFile("./slack.json", EMPTY_JSON_FILE);
+  mockFile.prepareVirtualFile("./slack.jsonc", EMPTY_JSON_FILE);
+  mockFile.prepareVirtualFile("./deno.json", EMPTY_JSON_FILE);
+  mockFile.prepareVirtualFile("./deno.jsonc", EMPTY_JSON_FILE);
+  mockFile.prepareVirtualFile("./import_map.json", EMPTY_JSON_FILE);
+  mockFile.prepareVirtualFile("./.slack/hooks.json", EMPTY_JSON_FILE);
+};
 
 Deno.test("check-update hook tests", async (t) => {
   // readProjectDependencies
   await t.step("readProjectDependencies method", async (evT) => {
     await evT.step(
-      "if dependency file contains recnognized dependency, version appears in returned map",
+      "if slack.json, deno.json & import_map.json contain recognized dependency, version appears in returned map",
       async () => {
+        setEmptyJsonFiles();
         mockFile.prepareVirtualFile("./slack.json", MOCK_SLACK_JSON_FILE);
         mockFile.prepareVirtualFile("./deno.json", MOCK_DENO_JSON_FILE);
         mockFile.prepareVirtualFile("./import_map.json", MOCK_IMPORT_MAP_FILE);
@@ -61,13 +78,46 @@ Deno.test("check-update hook tests", async (t) => {
         );
       },
     );
+
+    await evT.step(
+      "if .slack/hooks.json and deno.json contain recognized dependency, version appears in returned map",
+      async () => {
+        setEmptyJsonFiles();
+        mockFile.prepareVirtualFile(
+          "./.slack/hooks.json",
+          MOCK_DOT_SLACK_HOOKS_JSON_FILE,
+        );
+        mockFile.prepareVirtualFile(
+          "./deno.json",
+          MOCK_IMPORTS_IN_DENO_JSON_FILE,
+        );
+
+        const { versionMap } = await readProjectDependencies();
+
+        // Expected dependencies are present in returned versionMap
+        assertEquals(
+          true,
+          "deno_slack_hooks" in versionMap &&
+            "deno_slack_api" in versionMap &&
+            "deno_slack_hooks" in versionMap,
+        );
+
+        // Initial expected versionMap properties are present (name, current)
+        assertEquals(
+          true,
+          Object.values(versionMap).every((dep) => dep.name && dep.current),
+          "slack.json dependency wasn't found in returned versionMap",
+        );
+      },
+    );
   });
 
   // getDenoImportMapFiles
-  await t.step("getDenoImportMapFiles method", async (evT) => {
+  await t.step("getDenoImportFiles method", async (evT) => {
     await evT.step(
       "if deno.json file is unavailable, or no importMap key is present, an empty array is returned",
       async () => {
+        setEmptyJsonFiles();
         // Clear out deno.json file that's in memory from previous test(s)
         mockFile.prepareVirtualFile(
           "./deno.json",
@@ -75,7 +125,7 @@ Deno.test("check-update hook tests", async (t) => {
         );
 
         const cwd = Deno.cwd();
-        const { denoJSONDepFiles } = await getDenoImportMapFiles(cwd);
+        const { denoJSONDepFiles } = await getDenoImportFiles(cwd);
         const expected: [string, "imports"][] = [];
 
         assertEquals(
@@ -91,15 +141,36 @@ Deno.test("check-update hook tests", async (t) => {
     await evT.step(
       "if deno.json file is available, the correct filename + dependency key pair is returned",
       async () => {
+        setEmptyJsonFiles();
         const cwd = Deno.cwd();
         mockFile.prepareVirtualFile("./deno.json", MOCK_DENO_JSON_FILE);
 
-        const { denoJSONDepFiles } = await getDenoImportMapFiles(cwd);
+        const { denoJSONDepFiles } = await getDenoImportFiles(cwd);
 
         // Correct custom importMap file name is returned
         assertEquals(
           denoJSONDepFiles,
           [["import_map.json", "imports"]],
+        );
+      },
+    );
+
+    await evT.step(
+      "if deno.json containing imports is available, the correct filename + dependency key pair is returned",
+      async () => {
+        setEmptyJsonFiles();
+        const cwd = Deno.cwd();
+        mockFile.prepareVirtualFile(
+          "./deno.json",
+          MOCK_IMPORTS_IN_DENO_JSON_FILE,
+        );
+
+        const { denoJSONDepFiles } = await getDenoImportFiles(cwd);
+
+        // Correct import file name is returned
+        assertEquals(
+          denoJSONDepFiles,
+          [["deno.json", "imports"]],
         );
       },
     );
@@ -110,13 +181,14 @@ Deno.test("check-update hook tests", async (t) => {
     await evT.step(
       "given import_map.json or slack.json file contents, an array of key, value dependency pairs is returned",
       () => {
+        setEmptyJsonFiles();
         const importMapActual = extractDependencies(
-          JSON.parse(MOCK_IMPORT_MAP_JSON),
+          JSON.parse(MOCK_IMPORTS_JSON),
           "imports",
         );
 
         const slackHooksActual = extractDependencies(
-          JSON.parse(MOCK_SLACK_JSON),
+          JSON.parse(MOCK_HOOKS_JSON),
           "hooks",
         );
 

--- a/src/tests/install_update_test.ts
+++ b/src/tests/install_update_test.ts
@@ -34,14 +34,14 @@ const MOCK_RELEASES = [
   },
 ];
 
-const MOCK_SLACK_JSON = JSON.stringify({
+const MOCK_HOOKS_JSON = JSON.stringify({
   hooks: {
     "get-hooks":
       "deno run -q --allow-read --allow-net https://deno.land/x/deno_slack_hooks@0.0.9/mod.ts",
   },
 });
 
-const MOCK_IMPORT_MAP_JSON = JSON.stringify({
+const MOCK_IMPORTS_JSON = JSON.stringify({
   imports: {
     "deno-slack-sdk/": "https://deno.land/x/deno_slack_sdk@0.0.6/",
     "deno-slack-api/": "https://deno.land/x/deno_slack_api@0.0.6/",
@@ -52,9 +52,25 @@ const MOCK_DENO_JSON = JSON.stringify({
   "importMap": "import_map.json",
 });
 
-const MOCK_SLACK_JSON_FILE = new TextEncoder().encode(MOCK_SLACK_JSON);
-const MOCK_IMPORT_MAP_FILE = new TextEncoder().encode(MOCK_IMPORT_MAP_JSON);
+const MOCK_SLACK_JSON_FILE = new TextEncoder().encode(MOCK_HOOKS_JSON);
+const MOCK_DOT_SLACK_HOOKS_JSON_FILE = new TextEncoder().encode(
+  MOCK_HOOKS_JSON,
+);
+const MOCK_IMPORT_MAP_FILE = new TextEncoder().encode(MOCK_IMPORTS_JSON);
 const MOCK_DENO_JSON_FILE = new TextEncoder().encode(MOCK_DENO_JSON);
+const MOCK_IMPORTS_IN_DENO_JSON_FILE = new TextEncoder().encode(
+  MOCK_IMPORTS_JSON,
+);
+const EMPTY_JSON_FILE = new TextEncoder().encode("{}");
+
+const setEmptyJsonFiles = () => {
+  mockFile.prepareVirtualFile("./slack.json", EMPTY_JSON_FILE);
+  mockFile.prepareVirtualFile("./slack.jsonc", EMPTY_JSON_FILE);
+  mockFile.prepareVirtualFile("./deno.json", EMPTY_JSON_FILE);
+  mockFile.prepareVirtualFile("./deno.jsonc", EMPTY_JSON_FILE);
+  mockFile.prepareVirtualFile("./import_map.json", EMPTY_JSON_FILE);
+  mockFile.prepareVirtualFile("./.slack/hooks.json", EMPTY_JSON_FILE);
+};
 
 Deno.test("update hook tests", async (t) => {
   await t.step("createUpdateResp", async (evT) => {
@@ -74,10 +90,13 @@ Deno.test("update hook tests", async (t) => {
     await evT.step(
       "if referenced importMap in deno.json has available updates, then response includes those updates",
       async () => {
-        mockFile.prepareVirtualFile("./slack.json", MOCK_SLACK_JSON_FILE);
+        setEmptyJsonFiles();
+        mockFile.prepareVirtualFile(
+          "./slack.json",
+          MOCK_SLACK_JSON_FILE,
+        );
         mockFile.prepareVirtualFile("./deno.json", MOCK_DENO_JSON_FILE);
         mockFile.prepareVirtualFile("./import_map.json", MOCK_IMPORT_MAP_FILE);
-
         const expectedHooksUpdateSummary = [{
           name: "deno_slack_hooks",
           previous: "0.0.9",
@@ -107,6 +126,55 @@ Deno.test("update hook tests", async (t) => {
         };
 
         assertEquals(actual, expected);
+
+        mockFile.prepareVirtualFile(
+          "./slack.json",
+          new TextEncoder().encode("{}"),
+        );
+      },
+    );
+
+    await evT.step(
+      "if referenced imports in deno.json has available updates, then response includes those updates",
+      async () => {
+        setEmptyJsonFiles();
+        mockFile.prepareVirtualFile(
+          "./.slack/hooks.json",
+          MOCK_DOT_SLACK_HOOKS_JSON_FILE,
+        );
+        mockFile.prepareVirtualFile(
+          "./deno.jsonc",
+          MOCK_IMPORTS_IN_DENO_JSON_FILE,
+        );
+
+        const expectedHooksUpdateSummary = [{
+          name: "deno_slack_hooks",
+          previous: "0.0.9",
+          installed: "0.0.10",
+        }];
+
+        const expectedImportsUpdateSummary = [
+          {
+            name: "deno_slack_sdk",
+            previous: "0.0.6",
+            installed: "0.0.7",
+          },
+          {
+            name: "deno_slack_api",
+            previous: "0.0.6",
+            installed: "0.0.7",
+          },
+        ];
+
+        const actual = await createUpdateResp(MOCK_RELEASES);
+        const expected = {
+          name: SDK_NAME,
+          updates: [
+            ...expectedHooksUpdateSummary,
+            ...expectedImportsUpdateSummary,
+          ],
+        };
+        assertEquals(actual, expected);
       },
     );
   });
@@ -115,6 +183,7 @@ Deno.test("update hook tests", async (t) => {
     await evT.step(
       "if dependency updates are available, the correct update summary is returned",
       async () => {
+        setEmptyJsonFiles();
         const expectedHooksUpdateResp = [
           {
             name: "deno_slack_hooks",
@@ -161,6 +230,7 @@ Deno.test("update hook tests", async (t) => {
     await evT.step(
       "if file isn't found, an empty update array is returned",
       async () => {
+        setEmptyJsonFiles();
         assertEquals(
           await updateDependencyFile("./bad_file.json", MOCK_RELEASES),
           [],
@@ -174,8 +244,9 @@ Deno.test("update hook tests", async (t) => {
     await evT.step(
       "update versions are correctly mapped to the file's dependency map",
       () => {
-        const { hooks } = JSON.parse(MOCK_SLACK_JSON);
-        const { imports } = JSON.parse(MOCK_IMPORT_MAP_JSON);
+        setEmptyJsonFiles();
+        const { hooks } = JSON.parse(MOCK_HOOKS_JSON);
+        const { imports } = JSON.parse(MOCK_IMPORTS_JSON);
 
         const expectedHooksJSON = {
           hooks: {


### PR DESCRIPTION
### Summary

This PR aims to improve the `check-update` and `install-update` hooks to support `.slack/hooks.json` along with `"imports"` located in `deno.json` 

### Testing

1. Create a new Deno project from any of the sample apps
2. Use the following hooks in the project
```json
{
  "hooks": {
    "get-hooks": "deno run -q --allow-read --allow-net https://deno.land/x/deno_slack_hooks@1.3.2/mod.ts",
    "check-update": "deno run -q --config=deno.jsonc --allow-read --allow-net https://raw.githubusercontent.com/slackapi/deno-slack-hooks/refs/heads/support-dependency-updates-in-deno-json/src/check_update.ts",
    "install-update": "deno run -q --config=deno.jsonc --allow-run --allow-read --allow-write --allow-net https://raw.githubusercontent.com/slackapi/deno-slack-hooks/refs/heads/support-dependency-updates-in-deno-json/src/install_update.ts"
  }
}
```
3. Downgrade the version for
  a.  `"get-hooks"` in `.slack/hooks`
  b. `deno-slack-sdk/` or `deno-slack-api/` in `deno.jsonc`
4. run `lack update` -> the files should get updated 🟢 

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/{project_slug}/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
