### PR TITLE
fix: allow non import prefix

### DIFF
--- a/deno.jsonc
+++ b/deno.jsonc
@@ -12,7 +12,10 @@
   },
   "lint": {
     "include": ["src"],
-    "exclude": ["src/tests/fixtures"]
+    "exclude": ["src/tests/fixtures"],
+    "rules": {
+      "exclude": ["no-import-prefix"]
+    }
   },
   "test": {
     "include": ["src"],


### PR DESCRIPTION
### Summary

This PR configures the project to allow [non import prefixes](https://docs.deno.com/lint/rules/no-import-prefix/), non import prefixes are critical to this project since they lets the scripts referenced as commands in `mod.ts` be ran as standalone scripts

This should unblock #114 and #113

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/{project_slug}/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
