### PR TITLE
chore: Add .github/CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,12 @@
+# Salesforce Open Source project configuration
+# Learn more: https://github.com/salesforce/oss-template
+#ECCN:Open Source
+#GUSINFO:Open Source,Open Source Workflow
+
+# @slackapi/denosaurs
+# are code reviewers for all changes in this repo.
 * @slackapi/denosaurs
+
+# @slackapi/developer-education
+# are code reviewers for changes in the `/docs` directory.
+/docs/ @slackapi/developer-education


### PR DESCRIPTION
### Summary

This pull request adds a `.github/CODEOWNERS` file to adhere to the Salesforce Open Source project requirements. 

I've also added the Education team for the `docs/` directory (even though the docs directory doesn't exist) and comments to match https://github.com/slackapi/deno-slack-sdk.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/{project_slug}/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
